### PR TITLE
Improved binary read and write support

### DIFF
--- a/GeneratorUnitTests/GeneratorUnitTests.csproj
+++ b/GeneratorUnitTests/GeneratorUnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>GeneratorUnitTests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,8 +36,8 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -64,6 +67,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/GeneratorUnitTests/packages.config
+++ b/GeneratorUnitTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="NUnit" version="3.7.1" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net452" />
 </packages>

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -215,7 +215,7 @@ namespace glTFLoader
             binaryWriter.Write(jsonChunk.Length + jsonPadding);
             binaryWriter.Write(JSON);            
             binaryWriter.Write(jsonChunk);
-            for (int i = 0; i < jsonPadding; ++i) binaryWriter.Write((Byte)0);
+            for (int i = 0; i < jsonPadding; ++i) binaryWriter.Write((Byte)0x20);
             
             binaryWriter.Write(buffer.Length + binPadding);
             binaryWriter.Write(BIN);

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -194,12 +194,14 @@ namespace glTFLoader
         {
             var jsonText = JsonConvert.SerializeObject(model, Formatting.None);
             var jsonChunk = Encoding.UTF8.GetBytes(jsonText);
-            var jsonPadding = jsonChunk.Length & 3; if (jsonPadding != 0) jsonPadding = 4 - jsonPadding;            
+            var jsonPadding = jsonChunk.Length & 3; if (jsonPadding != 0) jsonPadding = 4 - jsonPadding;
+
+            var binPadding = buffer.Length & 3; if (binPadding != 0) binPadding = 4 - binPadding;
 
             int fullLength = 4 + 4 + 4;            
 
             fullLength += 8 + jsonChunk.Length + jsonPadding;
-            fullLength += 8 + buffer.Length;
+            fullLength += 8 + buffer.Length + binPadding;
 
             binaryWriter.Write(GLTF);
             binaryWriter.Write((UInt32)2);
@@ -210,9 +212,10 @@ namespace glTFLoader
             binaryWriter.Write(jsonChunk);
             for (int i = 0; i < jsonPadding; ++i) binaryWriter.Write((Byte)0);
             
-            binaryWriter.Write(buffer.Length);
+            binaryWriter.Write(buffer.Length + binPadding);
             binaryWriter.Write(BIN);
-            binaryWriter.Write(buffer);            
+            binaryWriter.Write(buffer);
+            for (int i = 0; i < binPadding; ++i) binaryWriter.Write((Byte)0);
         }
 
     }

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -17,12 +17,12 @@ namespace glTFLoader
         const uint JSON = 0x4E4F534A;
         const uint BIN = 0x004E4942;
 
-        const string EMBEDDEDOCTETSTREAM = "data:application/octet-stream;base64";
-        const string EMBEDDEDPNG = "data:image/png;base64";
-        const string EMBEDDEDBMP = "data:image/bmp;base64";
-        const string EMBEDDEDGIF = "data:image/gif;base64";
-        const string EMBEDDEDJPEG = "data:image/jpeg;base64";
-        const string EMBEDDEDTIFF = "data:image/tiff;base64";
+        const string EMBEDDEDOCTETSTREAM = "data:application/octet-stream;base64,";
+        const string EMBEDDEDPNG = "data:image/png;base64,";
+        const string EMBEDDEDBMP = "data:image/bmp;base64,";
+        const string EMBEDDEDGIF = "data:image/gif;base64,";
+        const string EMBEDDEDJPEG = "data:image/jpeg;base64,";
+        const string EMBEDDEDTIFF = "data:image/tiff;base64,";
 
         public static Gltf LoadModel(string filePath)
         {
@@ -142,9 +142,9 @@ namespace glTFLoader
 
             if (buffer.Uri == null) return LoadBinaryBuffer(gltfFilePath);
 
-            if (buffer.Uri.StartsWith("data:application/octet-stream;base64"))
+            if (buffer.Uri.StartsWith(EMBEDDEDOCTETSTREAM))
             {
-                var content = buffer.Uri.Substring(EMBEDDEDOCTETSTREAM.Length + 1);
+                var content = buffer.Uri.Substring(EMBEDDEDOCTETSTREAM.Length);
                 return Convert.FromBase64String(content);
             }
 
@@ -192,11 +192,11 @@ namespace glTFLoader
             {
                 string content = null;
 
-                if (image.Uri.StartsWith(EMBEDDEDPNG)) content = image.Uri.Substring(EMBEDDEDPNG.Length + 1);
-                if (image.Uri.StartsWith(EMBEDDEDBMP)) content = image.Uri.Substring(EMBEDDEDBMP.Length + 1);
-                if (image.Uri.StartsWith(EMBEDDEDGIF)) content = image.Uri.Substring(EMBEDDEDGIF.Length + 1);
-                if (image.Uri.StartsWith(EMBEDDEDJPEG)) content = image.Uri.Substring(EMBEDDEDJPEG.Length + 1);
-                if (image.Uri.StartsWith(EMBEDDEDTIFF)) content = image.Uri.Substring(EMBEDDEDTIFF.Length + 1);                
+                if (image.Uri.StartsWith(EMBEDDEDPNG)) content = image.Uri.Substring(EMBEDDEDPNG.Length);
+                if (image.Uri.StartsWith(EMBEDDEDBMP)) content = image.Uri.Substring(EMBEDDEDBMP.Length);
+                if (image.Uri.StartsWith(EMBEDDEDGIF)) content = image.Uri.Substring(EMBEDDEDGIF.Length);
+                if (image.Uri.StartsWith(EMBEDDEDJPEG)) content = image.Uri.Substring(EMBEDDEDJPEG.Length);
+                if (image.Uri.StartsWith(EMBEDDEDTIFF)) content = image.Uri.Substring(EMBEDDEDTIFF.Length);                
 
                 var bytes = Convert.FromBase64String(content);
                 return new MemoryStream(bytes);

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -114,6 +114,11 @@ namespace glTFLoader
                 ReadBinaryJsonChunk(binaryReader);
 
                 uint chunkLength = binaryReader.ReadUInt32();
+                if ((chunkLength & 3) != 0)
+                {
+                    throw new NotImplementedException($"The second chunk must be padded to 4 bytes: {chunkLength}");
+                }
+
                 uint chunkFormat = binaryReader.ReadUInt32();
                 if (chunkFormat != BIN)
                 {

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -19,11 +19,8 @@ namespace glTFLoader
         const uint VERSION2 = 2;
 
         const string EMBEDDEDOCTETSTREAM = "data:application/octet-stream;base64,";
-        const string EMBEDDEDPNG = "data:image/png;base64,";
-        const string EMBEDDEDBMP = "data:image/bmp;base64,";
-        const string EMBEDDEDGIF = "data:image/gif;base64,";
-        const string EMBEDDEDJPEG = "data:image/jpeg;base64,";
-        const string EMBEDDEDTIFF = "data:image/tiff;base64,";
+        const string EMBEDDEDPNG = "data:image/png;base64,";        
+        const string EMBEDDEDJPEG = "data:image/jpeg;base64,";        
 
         public static Gltf LoadModel(string filePath)
         {
@@ -204,11 +201,8 @@ namespace glTFLoader
         {
             string content = null;
 
-            if (image.Uri.StartsWith(EMBEDDEDPNG)) content = image.Uri.Substring(EMBEDDEDPNG.Length);
-            if (image.Uri.StartsWith(EMBEDDEDBMP)) content = image.Uri.Substring(EMBEDDEDBMP.Length);
-            if (image.Uri.StartsWith(EMBEDDEDGIF)) content = image.Uri.Substring(EMBEDDEDGIF.Length);
-            if (image.Uri.StartsWith(EMBEDDEDJPEG)) content = image.Uri.Substring(EMBEDDEDJPEG.Length);
-            if (image.Uri.StartsWith(EMBEDDEDTIFF)) content = image.Uri.Substring(EMBEDDEDTIFF.Length);
+            if (image.Uri.StartsWith(EMBEDDEDPNG)) content = image.Uri.Substring(EMBEDDEDPNG.Length);            
+            if (image.Uri.StartsWith(EMBEDDEDJPEG)) content = image.Uri.Substring(EMBEDDEDJPEG.Length);            
 
             var bytes = Convert.FromBase64String(content);
             return new MemoryStream(bytes);

--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -17,6 +17,45 @@ namespace glTFLoaderUnitTests
             AbsolutePathToSchemaDir = Path.Combine(TestContext.CurrentContext.TestDirectory, RelativePathToSchemaDir);
         }
 
+        private glTFLoader.Schema.Gltf TestLoadFile(string filePath)
+        {
+            if (!filePath.EndsWith("gltf") && !filePath.EndsWith("glb")) return null;
+
+            try
+            {
+                var deserializedFile = Interface.LoadModel(filePath);
+                Assert.IsNotNull(deserializedFile);
+
+                // read all buffers
+                for(int i=0; i < deserializedFile.Buffers?.Length; ++i)                
+                {
+                    var bufferBytes = deserializedFile.LoadBinaryBuffer(filePath, i);
+                    Assert.IsNotNull(bufferBytes);
+                    Assert.IsTrue(deserializedFile.Buffers[i].ByteLength <= bufferBytes.Length);
+                }                
+
+                // open all images
+                for(int i=0; i < deserializedFile.Images?.Length; ++i)
+                {
+                    using (var s = deserializedFile.OpenImageFile(filePath, i))
+                    {
+                        Assert.IsNotNull(s);
+
+                        var imageHeader = new Byte[16];
+                        s.Read(imageHeader, 0, 16);                        
+
+                        // TODO: here we could check actual image headers against the expected mime type.
+                    }
+                }
+
+                return deserializedFile;                
+            }            
+            catch (Exception e)
+            {
+                throw new Exception(filePath, e);
+            }
+        }
+
         [Test]
         public void SchemaLoad()
         {
@@ -24,18 +63,7 @@ namespace glTFLoaderUnitTests
             {
                 foreach (var file in Directory.EnumerateFiles(Path.Combine(dir, "glTF")))
                 {
-                    if (file.EndsWith("gltf"))
-                    {
-                        try
-                        {
-                            var deserializedFile = Interface.LoadModel(file);
-                            Assert.IsNotNull(deserializedFile);
-                        }
-                        catch (Exception e)
-                        {
-                            throw new Exception(file, e);
-                        }
-                    }
+                    TestLoadFile(file);
                 }
             }
         }
@@ -83,8 +111,40 @@ namespace glTFLoaderUnitTests
                         {
                             try
                             {
-                                var deserializedFile = Interface.LoadModel(file);
+                                var len = new FileInfo(file).Length;
+                                Assert.IsTrue((len & 3) == 0);
+
+                                var deserializedFile = TestLoadFile(file);
                                 Assert.IsNotNull(deserializedFile);
+
+                                var jsonChunk = Interface.LoadModel(file);
+                                Assert.IsNotNull(jsonChunk);
+
+                                var binChunk = Interface.LoadBinaryBuffer(file);
+
+                                Assert.IsNotNull(binChunk);
+                                Assert.IsTrue((binChunk.Length & 3) == 0);
+
+                                Assert.IsTrue(jsonChunk.Buffers[0].ByteLength <= binChunk.Length);
+                                // should we check padding as with jsonChunk? some reference files fail!
+
+                                // write to memory and reload again
+                                using (var wm = new MemoryStream())
+                                {
+                                    jsonChunk.SaveBinaryModel(binChunk, wm);
+
+                                    using (var rm = new MemoryStream(wm.ToArray()))
+                                    {
+                                        Interface.LoadModel(rm);
+                                    }
+
+                                    using (var rm = new MemoryStream(wm.ToArray()))
+                                    {
+                                        Interface.LoadBinaryBuffer(rm);
+                                    }
+                                }
+
+
                             }
                             catch (Exception e)
                             {
@@ -99,6 +159,8 @@ namespace glTFLoaderUnitTests
         [Test]
         public void EmbeddedSchemaLoad()
         {
+            TestLoadFile(@"D:\(_GitHub_)\glTF-Sample-Models\2.0\BoxTextured\glTF-Embedded\BoxTextured.gltf");
+
             foreach (var dir in Directory.EnumerateDirectories(Path.GetFullPath(AbsolutePathToSchemaDir)))
             {
                 string path = Path.Combine(dir, "glTF-Embedded");
@@ -106,18 +168,7 @@ namespace glTFLoaderUnitTests
                 {
                     foreach (var file in Directory.EnumerateFiles(path))
                     {
-                        if (file.EndsWith("gltf"))
-                        {
-                            try
-                            {
-                                var deserializedFile = Interface.LoadModel(file);
-                                Assert.IsNotNull(deserializedFile);
-                            }
-                            catch (Exception e)
-                            {
-                                throw new Exception(file, e);
-                            }
-                        }
+                        TestLoadFile(file);
                     }
                 }
             }
@@ -133,18 +184,7 @@ namespace glTFLoaderUnitTests
                 {
                     foreach (var file in Directory.EnumerateFiles(path))
                     {
-                        if (file.EndsWith("gltf"))
-                        {
-                            try
-                            {
-                                var deserializedFile = Interface.LoadModel(file);
-                                Assert.IsNotNull(deserializedFile);
-                            }
-                            catch (Exception e)
-                            {
-                                throw new Exception(file, e);
-                            }
-                        }
+                        TestLoadFile(file);
                     }
                 }
             }
@@ -160,18 +200,7 @@ namespace glTFLoaderUnitTests
                 {
                     foreach (var file in Directory.EnumerateFiles(path))
                     {
-                        if (file.EndsWith("gltf"))
-                        {
-                            try
-                            {
-                                var deserializedFile = Interface.LoadModel(file);
-                                Assert.IsNotNull(deserializedFile);
-                            }
-                            catch (Exception e)
-                            {
-                                throw new Exception(file, e);
-                            }
-                        }
+                        TestLoadFile(file);
                     }
                 }
             }
@@ -187,66 +216,10 @@ namespace glTFLoaderUnitTests
                 {
                     foreach (var file in Directory.EnumerateFiles(path))
                     {
-                        if (file.EndsWith("gltf"))
-                        {
-                            try
-                            {
-                                var deserializedFile = Interface.LoadModel(file);
-                                Assert.IsNotNull(deserializedFile);
-                            }
-                            catch (Exception e)
-                            {
-                                throw new Exception(file, e);
-                            }
-                        }
+                        TestLoadFile(file);
                     }
                 }
             }
-        }
-
-        [Test]
-        public void BinaryLoad()
-        {
-            foreach (var file in Directory.EnumerateFiles(AbsolutePathToSchemaDir, "*.glb", SearchOption.AllDirectories))
-            {
-                try
-                {
-                    var len = new FileInfo(file).Length;
-
-                    Assert.IsTrue((len & 3) == 0);
-
-                    var jsonChunk = Interface.LoadModel(file);
-                    Assert.IsNotNull(jsonChunk);
-
-                    var binChunk = Interface.LoadBinaryBuffer(file);
-                    Assert.IsNotNull(binChunk);
-                    Assert.IsTrue((binChunk.Length & 3) == 0);
-
-                    var buffer = jsonChunk.Buffers[0];
-                    Assert.IsTrue(buffer.ByteLength <= binChunk.Length);
-                    // should we check padding as with jsonChunk? some reference files fail!
-
-                    // write to memory and reload again
-                    using (var wm = new MemoryStream())
-                    {
-                        jsonChunk.SaveBinaryModel(binChunk, wm);
-
-                        using (var rm = new MemoryStream(wm.ToArray()))
-                        {
-                            Interface.LoadModel(rm);
-                        }
-
-                        using (var rm = new MemoryStream(wm.ToArray()))
-                        {
-                            Interface.LoadBinaryBuffer(rm);
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new Exception(file, e);
-                }
-            }
-        }
+        }        
     }
 }

--- a/glTFLoaderUnitTests/glTFLoaderUnitTests.csproj
+++ b/glTFLoaderUnitTests/glTFLoaderUnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>glTFLoaderUnitTests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,8 +36,8 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -62,6 +65,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/glTFLoaderUnitTests/packages.config
+++ b/glTFLoaderUnitTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="NUnit" version="3.7.1" targetFramework="net452" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Something that was missing from the current interface was the ability to read the binary buffer chunk from a glb file, and the ability to write glb files.

Notice that with the current API, we need to open the file two times, because the json chunk and the binary chunk are read separately (as if they were separate files)

I added these functions, along with a test that reads and writes binary files.

Also, I added an additional check for the byte padding for the json chunk.

I noticed some glb files don't have any padding on the binary buffer chunk. I understand it's because it's the last chunk... but, if in the future more chunk types are added, this might be an issue.

Finally, I added a unit test for the new methods.
