### PR TITLE
Don't write uri when it is null

### DIFF
--- a/GeneratorLib/SingleValueCodegenTypeFactory.cs
+++ b/GeneratorLib/SingleValueCodegenTypeFactory.cs
@@ -22,6 +22,7 @@ namespace GeneratorLib
                     case UriType.Image:
                     case UriType.Text:
                         returnType.CodeType = new CodeTypeReference(typeof(string));
+                        returnType.AdditionalMembers.Add(Helpers.CreateMethodThatChecksIfTheValueOfAMemberIsNotEqualToAnotherExpression(name, new CodePrimitiveExpression(null)));
                         break;
                     case UriType.None:
                         throw new InvalidDataException("UriType must be specified in the schema");

--- a/glTFLoader/glTFLoader.csproj
+++ b/glTFLoader/glTFLoader.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/KhronosGroup/glTF-CSharp-Loader</RepositoryUrl>
     <PackageIconUrl>https://github.com/KhronosGroup/glTF/blob/master/specification/figures/gltf.png</PackageIconUrl>
     <PackageTags>glTF loader C#</PackageTags>
-    <Version>1.1.0-alpha</Version>
+    <Version>1.1.1-alpha</Version>
   </PropertyGroup>  
 
   <ItemGroup>


### PR DESCRIPTION
  This is useful when writing out GLBs or otherwise it will fail validation.