### PR TITLE
Fixed not being able to assign null to array properties with length restrictions

### DIFF
--- a/GeneratorLib/ArrayValueCodegenTypeFactory.cs
+++ b/GeneratorLib/ArrayValueCodegenTypeFactory.cs
@@ -189,7 +189,7 @@ namespace GeneratorLib
                             },
                             Right = new CodePropertySetValueReferenceExpression()
                         },
-						new CodeMethodReturnStatement()
+                        new CodeMethodReturnStatement()
                     }
                 });
             }

--- a/GeneratorLib/ArrayValueCodegenTypeFactory.cs
+++ b/GeneratorLib/ArrayValueCodegenTypeFactory.cs
@@ -188,7 +188,8 @@ namespace GeneratorLib
                                 TargetObject = new CodeThisReferenceExpression()
                             },
                             Right = new CodePropertySetValueReferenceExpression()
-                        }
+                        },
+						new CodeMethodReturnStatement()
                     }
                 });
             }

--- a/GeneratorLib/ArrayValueCodegenTypeFactory.cs
+++ b/GeneratorLib/ArrayValueCodegenTypeFactory.cs
@@ -167,31 +167,31 @@ namespace GeneratorLib
 
         private static void EnforceRestrictionsOnSetValues(CodegenType returnType, string name, Schema schema)
         {
-			if (!schema.HasDefaultValue())
-			{
-				var fieldName = Helpers.GetFieldName(name);
-				returnType.SetStatements.Add(new CodeConditionStatement
-				{
-					Condition = new CodeBinaryOperatorExpression
-					{
-						Left = new CodePropertySetValueReferenceExpression(),
-						Operator = CodeBinaryOperatorType.ValueEquality,
-						Right = new CodePrimitiveExpression(null)
-					},
-					TrueStatements =
-					{
-						new CodeAssignStatement()
-						{
-							Left = new CodeFieldReferenceExpression
-							{
-								FieldName = fieldName,
-								TargetObject = new CodeThisReferenceExpression()
-							},
-							Right = new CodePropertySetValueReferenceExpression()
-						}
-					}
-				});
-			}
+            if (!schema.HasDefaultValue())
+            {
+                var fieldName = Helpers.GetFieldName(name);
+                returnType.SetStatements.Add(new CodeConditionStatement
+                {
+                    Condition = new CodeBinaryOperatorExpression
+                    {
+                        Left = new CodePropertySetValueReferenceExpression(),
+                        Operator = CodeBinaryOperatorType.ValueEquality,
+                        Right = new CodePrimitiveExpression(null)
+                    },
+                    TrueStatements =
+                    {
+                        new CodeAssignStatement()
+                        {
+                            Left = new CodeFieldReferenceExpression
+                            {
+                                FieldName = fieldName,
+                                TargetObject = new CodeThisReferenceExpression()
+                            },
+                            Right = new CodePropertySetValueReferenceExpression()
+                        }
+                    }
+                });
+            }
 
             if (schema.MinItems != null)
             {

--- a/GeneratorLib/ArrayValueCodegenTypeFactory.cs
+++ b/GeneratorLib/ArrayValueCodegenTypeFactory.cs
@@ -167,6 +167,32 @@ namespace GeneratorLib
 
         private static void EnforceRestrictionsOnSetValues(CodegenType returnType, string name, Schema schema)
         {
+			if (!schema.HasDefaultValue())
+			{
+				var fieldName = Helpers.GetFieldName(name);
+				returnType.SetStatements.Add(new CodeConditionStatement
+				{
+					Condition = new CodeBinaryOperatorExpression
+					{
+						Left = new CodePropertySetValueReferenceExpression(),
+						Operator = CodeBinaryOperatorType.ValueEquality,
+						Right = new CodePrimitiveExpression(null)
+					},
+					TrueStatements =
+					{
+						new CodeAssignStatement()
+						{
+							Left = new CodeFieldReferenceExpression
+							{
+								FieldName = fieldName,
+								TargetObject = new CodeThisReferenceExpression()
+							},
+							Right = new CodePropertySetValueReferenceExpression()
+						}
+					}
+				});
+			}
+
             if (schema.MinItems != null)
             {
                 returnType.SetStatements.Add(new CodeConditionStatement

--- a/GeneratorLib/CodeGenerator.cs
+++ b/GeneratorLib/CodeGenerator.cs
@@ -263,8 +263,8 @@ namespace GeneratorLib
 
         private void AddProperty(CodeTypeDeclaration target, string rawName, Schema schema)
         {
-            var name = Helpers.ParsePropertyName(rawName);
-            var fieldName = "m_" + name.Substring(0, 1).ToLower() + name.Substring(1);
+            var propertyName = Helpers.ParsePropertyName(rawName);
+			var fieldName = Helpers.GetFieldName(propertyName);
             var codegenType = CodegenTypeFactory.MakeCodegenType(rawName, schema);
             target.Members.AddRange(codegenType.AdditionalMembers);
 
@@ -272,7 +272,7 @@ namespace GeneratorLib
             {
                 Type = codegenType.CodeType,
                 Name = fieldName,
-                Comments = { new CodeCommentStatement("<summary>", true), new CodeCommentStatement($"Backing field for {name}.", true), new CodeCommentStatement("</summary>", true) },
+                Comments = { new CodeCommentStatement("<summary>", true), new CodeCommentStatement($"Backing field for {propertyName}.", true), new CodeCommentStatement("</summary>", true) },
                 InitExpression = codegenType.DefaultValue
             };
 
@@ -292,7 +292,7 @@ namespace GeneratorLib
             var property = new CodeMemberProperty
             {
                 Type = codegenType.CodeType,
-                Name = name,
+                Name = propertyName,
                 Attributes = MemberAttributes.Public | MemberAttributes.Final,
                 HasGet = true,
                 GetStatements = { new CodeMethodReturnStatement(new CodeFieldReferenceExpression(new CodeThisReferenceExpression(), fieldName)) },

--- a/GeneratorLib/CodeGenerator.cs
+++ b/GeneratorLib/CodeGenerator.cs
@@ -264,7 +264,7 @@ namespace GeneratorLib
         private void AddProperty(CodeTypeDeclaration target, string rawName, Schema schema)
         {
             var propertyName = Helpers.ParsePropertyName(rawName);
-			var fieldName = Helpers.GetFieldName(propertyName);
+            var fieldName = Helpers.GetFieldName(propertyName);
             var codegenType = CodegenTypeFactory.MakeCodegenType(rawName, schema);
             target.Members.AddRange(codegenType.AdditionalMembers);
 

--- a/GeneratorLib/Helpers.cs
+++ b/GeneratorLib/Helpers.cs
@@ -4,6 +4,11 @@ namespace GeneratorLib
 {
     public static class Helpers
     {
+		public static string GetFieldName(string name)
+		{
+			return "m_" + name.Substring(0, 1).ToLower() + name.Substring(1);
+		}
+
         public static string ParsePropertyName(string rawName)
         {
             return rawName.Substring(0, 1).ToUpper() + rawName.Substring(1);

--- a/GeneratorLib/Helpers.cs
+++ b/GeneratorLib/Helpers.cs
@@ -4,10 +4,10 @@ namespace GeneratorLib
 {
     public static class Helpers
     {
-		public static string GetFieldName(string name)
-		{
-			return "m_" + name.Substring(0, 1).ToLower() + name.Substring(1);
-		}
+        public static string GetFieldName(string name)
+        {
+            return "m_" + name.Substring(0, 1).ToLower() + name.Substring(1);
+        }
 
         public static string ParsePropertyName(string rawName)
         {


### PR DESCRIPTION
I was running into an issue where I could not remove/nullify extensions from gltf files due to the array length conditions throwing null reference errors.

The conflicting code:
```
public string[] ExtensionsUsed {
    get {
        return this.m_extensionsUsed;
    }
    set {
        if ((value.Length < 1u)) { // value.Length will through a null reference exception when value is null
            throw new System.ArgumentException("Array not long enough");
        }
        this.m_extensionsUsed = value;
    }
}
```

Fixed code (after my code gen changes):
```
public string[] ExtensionsUsed {
    get {
        return this.m_extensionsUsed;
    }
    set {
        if ((value == null)) { // New condition to fix the null reference error
            this.m_extensionsUsed = value;
            return;
        }
        if ((value.Length < 1u)) {
            throw new System.ArgumentException("Array not long enough");
        }
        this.m_extensionsUsed = value;
    }
}
```

I altered the code gen to assign the property and return if the value is null. I'm not familiar with the code gen system so if there's a better way to apply this fix, let me know.