### PR TITLE
pack methods (direct file to file, and with binary buffer chunck)

### DIFF
--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -95,7 +95,7 @@ namespace glTFLoaderUnitTests
             foreach (var file in GetTestFiles(subdirectory))
             {
                 var gltf = TestLoadFile(file);
-
+                
                 // serialization as glTF (in memory)
                 using (var wm = new MemoryStream())
                 {
@@ -137,13 +137,18 @@ namespace glTFLoaderUnitTests
         {
             foreach (var file in GetTestFiles(subdirectory))
             {
-                var gltf = TestLoadFile(file);
-
                 string tempOutputFile = Path.GetTempFileName();
                 string glbOutputFile = Path.ChangeExtension(tempOutputFile, "glb");
 
-                Interface.SaveBinaryModelPacked(gltf, glbOutputFile, file);
+                // pack file
+                Interface.Pack(file, glbOutputFile);
+                TestLoadFile(glbOutputFile);
 
+                // pack model test
+                var gltf = TestLoadFile(file);               
+
+                // pack model
+                Interface.SaveBinaryModelPacked(gltf, glbOutputFile, file);
                 TestLoadFile(glbOutputFile);
 
                 File.Delete(tempOutputFile);

--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -145,7 +145,7 @@ namespace glTFLoaderUnitTests
                 TestLoadFile(glbOutputFile);
 
                 // pack model test
-                var gltf = TestLoadFile(file);               
+                var gltf = TestLoadFile(file);
 
                 // pack model
                 Interface.SaveBinaryModelPacked(gltf, glbOutputFile, file);


### PR DESCRIPTION
Hi @bghgary. Sorry for this new PR. Just some additions that I need and that deserves to be shared.

- Direct `Interface.Pack(in, out)` method that packs a glTF file to self contained GLB.
- One more argument to the `SaveBinaryModelPacked` method that allows GLB generation when buffer data is supplied by the user. 
I needed this because in case of a model generation where both .gtlf and packed .glb files are generated, it is handy to directly use the GLB buffer data to pack instead of fetching it again.

Hope this make sense. Cheers.