### PR TITLE
Fix unit test to account for gltf_sectiondescription.

### DIFF
--- a/GeneratorUnitTests/SchemaTest.cs
+++ b/GeneratorUnitTests/SchemaTest.cs
@@ -84,7 +84,7 @@ namespace GeneratorUnitTests
             propertyNames = propertyNames.Select((p) => p.ToLower()).Distinct().ToList();
             var knownPropertyNames = typeof(Schema).GetProperties().Select((p) => p.Name.ToLower());
             propertyNames = propertyNames.Except(knownPropertyNames).Except(excludedNames)
-                .Except(new[] { "$schema", "__ref__", "additionalproperties", "gltf_webgl", "gltf_detaileddescription", "gltf_enumnames", "gltf_uritype" }).ToList();
+                .Except(new[] { "$schema", "__ref__", "additionalproperties", "gltf_webgl", "gltf_detaileddescription", "gltf_sectiondescription", "gltf_enumnames", "gltf_uritype" }).ToList();
 
             CollectionAssert.AreEquivalent(new string[] { }, propertyNames);
         }


### PR DESCRIPTION
This is a new gltf-specific identifier introduced in https://github.com/CesiumGS/wetzel/pull/42.  The unit tests here merely have to ignore it.