### PR TITLE
Remove stale flavors that no longer exist in the sample model repo.

### DIFF
--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -87,9 +87,6 @@ namespace glTFLoaderUnitTests
         [TestCase("glTF")]
         [TestCase("glTF-Binary")]
         [TestCase("glTF-Embedded")]
-        [TestCase("glTF-MaterialsCommon")]
-        [TestCase("glTF-pbrSpecularGlossiness")]
-        [TestCase("glTF-techniqueWebGL")]
         public void SchemaLoad(string subdirectory)
         {
             foreach (var file in GetTestFiles(subdirectory))


### PR DESCRIPTION
Removed 3 "flavors" of glTF sample models that no longer exist in the sample model repo:

- `glTF-MaterialsCommon`
- `glTF-pbrSpecularGlossiness`
- `glTF-techniqueWebGL`

The `glTF-pbrSpecularGlossiness` one in particular is no longer a "flavor" (alongside `glTF-Binary` etc), but instead is tested via a single sample model (SpecGlossVsMetalRough) using the classic plain & binary flavors.

The other two are completely deprecated.