### PR TITLE
Updated JSON schema to handle 2020-12

### DIFF
--- a/CSharp.sln
+++ b/CSharp.sln
@@ -1,8 +1,5 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
-MinimumVisualStudioVersion = 10.0.40219.1
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Generator", "Generator\Generator.csproj", "{DDD005C7-D63D-4707-9464-1BCB9FD00454}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeneratorLib", "GeneratorLib\GeneratorLib.csproj", "{ED3BEBD3-A9B9-42D9-A778-43E8CFB3B359}"

--- a/GeneratorLib/CodeGenerator.cs
+++ b/GeneratorLib/CodeGenerator.cs
@@ -160,25 +160,22 @@ namespace GeneratorLib
         /// <summary>
         /// In glTF 2.0 an enumeration is defined by a property that contains
         /// the "anyOf" object that contains an array containing multiple
-        /// "enum" objects and a single "type" object.
+        /// "const" objects and a single "type" object.
         /// 
         ///   {
         ///     "properties" : {
         ///       "mimeType" : {
         ///         "anyOf" : [
-        ///           { "enum" : [ "image/jpeg" ] },
-        ///           { "enum" : [ "image/png" ] },
+        ///           { "const" : "image/jpeg" },
+        ///           { "const" : "image/png" },
         ///           { "type" : "string" }
         ///         ]
         ///       }
         ///     }
         ///   }
         ///   
-        /// Unlike the default Json Schema, each "enum" object array will
-        /// contain only one element for glTF.
-        /// 
         /// So if the property does not have a "type" object and it has an
-        /// "anyOf" object, assume it is an enum and attept to set the
+        /// "anyOf" object, assume it is an enum and attempt to set the
         /// appropriate schema properties.
         /// </summary>
         private void EvaluateEnums()

--- a/GeneratorLib/CodeGenerator.cs
+++ b/GeneratorLib/CodeGenerator.cs
@@ -142,6 +142,7 @@ namespace GeneratorLib
         public void PostProcessSchema()
         {
             SetDefaults();
+            SetExclusiveMinMax();
             EvaluateEnums();
             SetRequired();
         }
@@ -153,6 +154,50 @@ namespace GeneratorLib
                 if (schema.Type == null)
                 {
                     schema.Type = new[] { new TypeReference { IsReference = false, Name = "object" } };
+                }
+            }
+        }
+
+        private void SetExclusiveMinMax()
+        {
+            foreach (var schema in FileSchemas.Values)
+            {
+                if (schema.Properties != null)
+                {
+                    foreach (var property in schema.Properties)
+                    {
+                        var propertySchema = property.Value;
+
+                        // Exclusive Min
+                        if (propertySchema.RawExclusiveMinimum is bool)
+                        {
+                            // JSON schema draft-4, the old schema
+                            propertySchema.ExclusiveMinimum = Convert.ToBoolean(
+                                propertySchema.RawExclusiveMinimum);
+                        }
+                        else if (propertySchema.RawExclusiveMinimum is double ||
+                                 propertySchema.RawExclusiveMinimum is long)
+                        {
+                            // JSON schema draft 2020-12, the new schema
+                            propertySchema.Minimum = propertySchema.RawExclusiveMinimum;
+                            propertySchema.ExclusiveMinimum = true;
+                        }
+
+                        // Exclusive Max
+                        if (propertySchema.RawExclusiveMaximum is bool)
+                        {
+                            // JSON schema draft-4, the old schema
+                            propertySchema.ExclusiveMaximum = Convert.ToBoolean(
+                                propertySchema.RawExclusiveMaximum);
+                        }
+                        else if (propertySchema.RawExclusiveMaximum is double ||
+                                 propertySchema.RawExclusiveMaximum is long)
+                        {
+                            // JSON schema draft 2020-12, the new schema
+                            propertySchema.Maximum = propertySchema.RawExclusiveMaximum;
+                            propertySchema.ExclusiveMaximum = true;
+                        }
+                    }
                 }
             }
         }

--- a/GeneratorLib/Schema.cs
+++ b/GeneratorLib/Schema.cs
@@ -214,8 +214,27 @@ namespace GeneratorLib
 
             foreach (var dict in this.AnyOf)
             {
-                if (dict.ContainsKey("enum"))
+                if (dict.ContainsKey("const"))
                 {
+                    // Newer glTF 2.0 schema (as of September 2021) uses "const" for enums.
+                    var enumValue = dict["const"];
+                    if (this.Type?[0].Name == "integer")
+                    {
+                        this.Enum.Add(Convert.ToInt32(enumValue));
+                        this.EnumNames.Add(dict["description"].ToString());
+                    }
+                    else if (this.Type?[0].Name == "string")
+                    {
+                        this.Enum.Add(Convert.ToString(enumValue));
+                    }
+                    else
+                    {
+                        throw new NotImplementedException("Enum of " + this.Type?[0].Name);
+                    }
+                }
+                else if (dict.ContainsKey("enum"))
+                {
+                    // Older glTF schemas use the enum keyword.
                     JArray enumList = dict["enum"] as JArray;
                     if (this.Type?[0].Name == "integer")
                     {

--- a/GeneratorLib/Schema.cs
+++ b/GeneratorLib/Schema.cs
@@ -99,8 +99,16 @@ namespace GeneratorLib
         [JsonProperty("gltf_enumNames")]
         public IList<string> EnumNames { get; set; }
 
+        [JsonProperty("exclusiveMaximum")]
+        public object RawExclusiveMaximum { get; set; }
+
+        [JsonProperty("exclusiveMinimum")]
+        public object RawExclusiveMinimum { get; set; }
+
+        [JsonProperty("exclusiveMaximum_bool")]
         public bool ExclusiveMaximum { get; set; } = false;
 
+        [JsonProperty("exclusiveMinimum_bool")]
         public bool ExclusiveMinimum { get; set; } = false;
 
         public string Format { get; set; }

--- a/GeneratorUnitTests/SchemaTest.cs
+++ b/GeneratorUnitTests/SchemaTest.cs
@@ -84,7 +84,7 @@ namespace GeneratorUnitTests
             propertyNames = propertyNames.Select((p) => p.ToLower()).Distinct().ToList();
             var knownPropertyNames = typeof(Schema).GetProperties().Select((p) => p.Name.ToLower());
             propertyNames = propertyNames.Except(knownPropertyNames).Except(excludedNames)
-                .Except(new[] { "$schema", "__ref__", "additionalproperties", "gltf_webgl", "gltf_detaileddescription", "gltf_enumnames", "gltf_uritype" }).ToList();
+                .Except(new[] { "$schema", "__ref__", "additionalproperties", "gltf_webgl", "gltf_detaileddescription", "gltf_sectiondescription", "gltf_enumnames", "gltf_uritype" }).ToList();
 
             CollectionAssert.AreEquivalent(new string[] { }, propertyNames);
         }

--- a/GeneratorUnitTests/SchemaTest.cs
+++ b/GeneratorUnitTests/SchemaTest.cs
@@ -84,7 +84,9 @@ namespace GeneratorUnitTests
             propertyNames = propertyNames.Select((p) => p.ToLower()).Distinct().ToList();
             var knownPropertyNames = typeof(Schema).GetProperties().Select((p) => p.Name.ToLower());
             propertyNames = propertyNames.Except(knownPropertyNames).Except(excludedNames)
-                .Except(new[] { "$schema", "__ref__", "additionalproperties", "gltf_webgl", "gltf_detaileddescription", "gltf_sectiondescription", "gltf_enumnames", "gltf_uritype" }).ToList();
+                .Except(new[] { "$schema", "$id", "__ref__", "additionalproperties", "gltf_webgl",
+                    "gltf_detaileddescription", "gltf_sectiondescription", "const",
+                    "gltf_enumnames", "gltf_uritype" }).ToList();
 
             CollectionAssert.AreEquivalent(new string[] { }, propertyNames);
         }

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -164,10 +164,10 @@ namespace glTFLoader
         /// <returns>Lambda funcion to resolve dependencies</returns>
         private static Func<string, Byte[]> GetExternalFileSolver(string gltfFilePath)
         {
-            return asset =>
+            return uri =>
             {
-                if (string.IsNullOrEmpty(asset)) return LoadBinaryBuffer(gltfFilePath);
-                var bufferFilePath = Path.Combine(Path.GetDirectoryName(gltfFilePath), asset);
+                if (string.IsNullOrEmpty(uri)) return LoadBinaryBuffer(gltfFilePath);
+                var bufferFilePath = Path.Combine(Path.GetDirectoryName(gltfFilePath), Uri.UnescapeDataString(uri));
                 return File.ReadAllBytes(bufferFilePath);
             };
         }


### PR DESCRIPTION
The latest glTF JSON schema has been updated from draft-7 to draft 2020-12.

The main changes are that enums switched to using the `const` keyword, and a new means of specifying `exclusiveMinimum` was introduced.  Also, a few extra properties such as `$id` have appeared, but those are ignored here.

This PR adds the ability to read either the new or old schemas, whichever are found, as they are quite similar.

This builds on #34.

Fixes #21.
Fixes #35.

Written for https://github.com/KhronosGroup/glTF/pull/2034#issuecomment-926871454.