### PR TITLE
making the returned stream readable.

### DIFF
--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -337,7 +337,7 @@ namespace glTFLoader
         {
             string fileData = SerializeModel(model);
 
-            using (var ts = new StreamWriter(stream))
+            using (var ts = new StreamWriter(stream, leaveOpen: true))
             {
                 ts.Write(fileData);
             }


### PR DESCRIPTION
StreamWriter closes the stream so it is impossible to read from it.
We can leave it open and readable by specifying the leaveOpen parameter as true.

Fixes #39