### PR TITLE
Adjust getting mime type

### DIFF
--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -729,12 +729,12 @@ namespace glTFLoader
                 return null;
             }
 
-            if (uri.StartsWith("data:image/png;base64,") || uri.EndsWith(".png"))
+            if (uri.StartsWith("data:image/png;base64,") || uri.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
             {
                 return Image.MimeTypeEnum.image_png;
             }
 
-            if (uri.StartsWith("data:image/jpeg;base64,") || uri.EndsWith(".jpg") || uri.EndsWith(".jpeg"))
+            if (uri.StartsWith("data:image/jpeg;base64,") || uri.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) || uri.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase))
             {
                 return Image.MimeTypeEnum.image_jpeg;
             }


### PR DESCRIPTION
I met this issue using the package from another project dealing with user's caps locked file names. Though I fixed it renaming textures from my code, I thought it would be nice to eliminate the need of changing extensions.