### PR TITLE
Allow schema generator to load schema files from multiple directories

### DIFF
--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -1,33 +1,113 @@
 using KhronosGroup.Gltf.Generator.JsonSchema;
 
+using System.Collections.Generic;
 using System.IO;
 
 namespace KhronosGroup.Gltf.Generator
 {
     class Program
     {
+        static string defaultSchemaPath = Path.Combine(
+            // glTF-CSharp-Loader\Generator\bin\Debug\net7.0
+            "..", "..", "..", "..", "..",
+            "glTF", "specification", "2.0", "schema", "glTF.schema.json");
+        static string defaultOutputPath = Path.Combine(
+            "..", "..", "..", "..", "glTFLoader", "Schema");
+
+        static void Usage(int exitCode)
+        {
+            var executableName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+            System.Console.WriteLine($"Usage: {executableName} [options] [root schema file]");
+            System.Console.WriteLine("\t[options]");
+            System.Console.WriteLine("\t\t-h Display this help and exit");
+            System.Console.WriteLine("\t\t-search <directory> Search <directory> for schema file references");
+            System.Console.WriteLine($"\t\t-output <directory> Output to <directory> (default {defaultOutputPath})");
+            System.Console.WriteLine($"\t[root schema file] Schema file to parse (default {defaultSchemaPath})");
+            System.Environment.Exit(exitCode);
+        }
+
+        static void Error(string message)
+        {
+            System.Console.Error.WriteLine(message);
+            System.Environment.Exit(1);
+        }
+
         static void Main(string[] args)
         {
-            var schemaPath = Path.Combine(
-                // glTF-CSharp-Loader\Generator\bin\Debug\net7.0
-                "..", "..", "..", "..", "..",
-                "glTF", "specification", "2.0", "schema", "glTF.schema.json");
+            string rootSchemaPath = null;
+            string outputDirPath = null;
+            var searchDirs = new List<string>();
 
-            if (args.Length > 0)
+            for (int i = 0; i < args.Length; i++)
             {
-                schemaPath = args[args.Length - 1];
+                if (args[i] == "-h" || args[i] == "--help" || args[i] == "/?")
+                {
+                    Usage(0);
+                }
             }
 
-            if (!File.Exists(schemaPath))
-                throw new FileNotFoundException(
-                    $"Could not find '{Path.GetFileName(schemaPath)}' " +
-                    $"at '{Path.GetDirectoryName(schemaPath)}' " +
-                    $"(full path {Path.GetFullPath(Path.GetDirectoryName(schemaPath))}).");
-            var loader = new SchemaLoader(schemaPath);
-
-            for (int i = 0; i < args.Length - 1; i++)
+            for (int i = 0; i < args.Length; i++)
             {
-                loader.AppendSchemaSearchDirectory(args[i]);
+                if (args[i] == "-search")
+                {
+                    i++;
+                    if (args.Length > i && Path.Exists(args[i]) &&
+                        (File.GetAttributes(args[i]) & FileAttributes.Directory) != 0)
+                    {
+                        searchDirs.Add(args[i]);
+                    }
+                    else
+                    {
+                        Error("-search: Requires a directory");
+                    }
+                }
+                else if (args[i] == "-output")
+                {
+                    i++;
+                    if (args.Length > i && Path.Exists(args[i]) &&
+                        (File.GetAttributes(args[i]) & FileAttributes.Directory) != 0)
+                    {
+                        outputDirPath = args[i];
+                    }
+                    else
+                    {
+                        Error("-output: Requires a directory");
+                    }
+                 }
+                else
+                {
+                    if (File.Exists(args[i]) &&
+                        (File.GetAttributes(args[i]) & FileAttributes.Normal) != 0)
+                    {
+                        if (rootSchemaPath == null)
+                        {
+                            rootSchemaPath = args[i];
+                        }
+                        else
+                        {
+                            Error("Only one root schema can be specified");
+                        }
+                    }
+                    else
+                    {
+                        Error($"Unhandled argument: {args[i]}");
+                    }
+                }
+            }
+
+            rootSchemaPath = rootSchemaPath ?? defaultSchemaPath;
+            outputDirPath = outputDirPath ?? defaultOutputPath;
+
+            if (!File.Exists(rootSchemaPath))
+                throw new FileNotFoundException(
+                    $"Could not find '{Path.GetFileName(rootSchemaPath)}' " +
+                    $"at '{Path.GetDirectoryName(rootSchemaPath)}' " +
+                    $"(full path {Path.GetFullPath(Path.GetDirectoryName(rootSchemaPath))}).");
+            var loader = new SchemaLoader(rootSchemaPath);
+
+            for (int i = 0; i < searchDirs.Count; i++)
+            {
+                loader.AppendSchemaSearchDirectory(searchDirs[i]);
             }
 
             loader.ParseSchemas();
@@ -35,7 +115,6 @@ namespace KhronosGroup.Gltf.Generator
             loader.EvaluateInheritance();
             loader.PostProcessSchema();
             var generator = new CodeGenerator(loader.FileSchemas);
-            var outputDirPath = Path.Combine("..", "..", "..", "..", "glTFLoader", "Schema");
             generator.CSharpCodeGen(Path.GetFullPath(outputDirPath));
         }
     }

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -12,12 +12,24 @@ namespace KhronosGroup.Gltf.Generator
                 // glTF-CSharp-Loader\Generator\bin\Debug\net7.0
                 "..", "..", "..", "..", "..",
                 "glTF", "specification", "2.0", "schema", "glTF.schema.json");
+
+            if (args.Length > 0)
+            {
+                schemaPath = args[args.Length - 1];
+            }
+
             if (!File.Exists(schemaPath))
                 throw new FileNotFoundException(
                     $"Could not find '{Path.GetFileName(schemaPath)}' " +
                     $"at '{Path.GetDirectoryName(schemaPath)}' " +
                     $"(full path {Path.GetFullPath(Path.GetDirectoryName(schemaPath))}).");
             var loader = new SchemaLoader(schemaPath);
+
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                loader.AppendSchemaSearchDirectory(args[i]);
+            }
+
             loader.ParseSchemas();
             loader.ExpandSchemaReferences();
             loader.EvaluateInheritance();

--- a/GeneratorSchema/SchemaLoader.cs
+++ b/GeneratorSchema/SchemaLoader.cs
@@ -7,19 +7,26 @@ namespace KhronosGroup.Gltf.Generator.JsonSchema
 {
     public class SchemaLoader
     {
-        private readonly string m_directory;
+        private readonly List<string> m_directories;
         private readonly string m_rootSchemaName;
 
         public SchemaLoader(string rootSchemaFilePath)
         {
             rootSchemaFilePath = Path.GetFullPath(rootSchemaFilePath);
-            m_directory = Path.GetDirectoryName(rootSchemaFilePath);
+            m_directories = new List<string> { Path.GetDirectoryName(rootSchemaFilePath) };
             m_rootSchemaName = Path.GetFileName(rootSchemaFilePath);
         }
         public Dictionary<string, Schema> FileSchemas { get; private set; }
+
+        /// Adds `dirPath` to the set of directories to look in for schema references
+        public void AppendSchemaSearchDirectory(string dirPath)
+        {
+            m_directories.Add(dirPath);
+        }
+
         public void ParseSchemas()
         {
-            FileSchemas = new SchemaParser(m_directory).ParseSchemaTree(m_rootSchemaName);
+            FileSchemas = new SchemaParser(m_directories).ParseSchemaTree(m_rootSchemaName);
         }
         public void ExpandSchemaReferences()
         {

--- a/GeneratorSchema/SchemaParser.cs
+++ b/GeneratorSchema/SchemaParser.cs
@@ -6,11 +6,11 @@ namespace KhronosGroup.Gltf.Generator.JsonSchema
 {
     public class SchemaParser
     {
-        private string m_directory;
+        private List<string> m_directories;
 
-        public SchemaParser(string rootDirectory)
+        public SchemaParser(List<string> searchDirectories)
         {
-            m_directory = rootDirectory;
+            m_directories = searchDirectories;
         }
 
         private Dictionary<string, Schema> FileSchemas { get; set; }
@@ -105,9 +105,25 @@ namespace KhronosGroup.Gltf.Generator.JsonSchema
 
         private Schema Deserialize(string fileName)
         {
-            return JsonConvert.DeserializeObject<Schema>(
-                File.ReadAllText(Path.Combine(m_directory, fileName))
-                    .Replace("\"$ref\"", "__ref__"));
+            for (var i = 0; i < m_directories.Count; i++)
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<Schema>(
+                    File.ReadAllText(Path.Combine(m_directories[i], fileName))
+                        .Replace("\"$ref\"", "__ref__"));
+                }
+                catch (System.IO.FileNotFoundException)
+                {
+                    if (i == m_directories.Count -1)
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            // Should not be hit; either we'll Deserialize a file or raise an exception
+            return null;
         }
     }
 }


### PR DESCRIPTION
Today, the schema generator executable uses a hardcoded path to a schema file to start generation.

I had a use-case where I wanted to generate schemas for an extension; the extensions are in a different subdirectory to the base glTF spec. In the past, it seemed users who wanted to generate schemas for an extension were required to copy all the extension schema files to the same directory as the base glTF schema files and possibly edit the hardcoded paths in the generator.

This change adds some command-line arguments to the generator to allow specifying of search directories for schema files, selecting a "root" schema to parse and control of the output directory. The default values for these paths are preserved, to avoid breaking any existing tooling. This makes schema generation for extensions less disruptive.