### PR TITLE
Add CI with NuGet publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Publish the exact version from the csproj as a release (unchecked = preview).'
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: windows-latest
+    steps:
+      - name: Checkout glTF-CSharp-Loader
+        uses: actions/checkout@v4
+        with:
+          path: glTF-CSharp-Loader
+
+      # The code generator and its tests read the core glTF schema from a sibling glTF repo.
+      - name: Checkout glTF (schema)
+        uses: actions/checkout@v4
+        with:
+          repository: KhronosGroup/glTF
+          path: glTF
+          fetch-depth: 1
+
+      # The loader tests load every model from a sibling glTF-Sample-Assets repo.
+      # It is large, so shallow-clone it and cache the working tree (without .git) between runs.
+      - name: Determine glTF-Sample-Assets commit
+        id: assets
+        shell: bash
+        run: echo "sha=$(git ls-remote https://github.com/KhronosGroup/glTF-Sample-Assets.git HEAD | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache glTF-Sample-Assets
+        id: cache-assets
+        uses: actions/cache@v4
+        with:
+          path: glTF-Sample-Assets
+          key: gltf-sample-assets-${{ steps.assets.outputs.sha }}
+
+      - name: Clone glTF-Sample-Assets
+        if: steps.cache-assets.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/KhronosGroup/glTF-Sample-Assets.git glTF-Sample-Assets
+          rm -rf glTF-Sample-Assets/.git
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      # Build/test the specific projects rather than the whole solution so the code
+      # generator does not run and regenerate the checked-in schema during CI.
+      - name: Test generator
+        working-directory: glTF-CSharp-Loader
+        run: dotnet test GeneratorUnitTests/GeneratorUnitTests.csproj -c Release
+
+      - name: Test loader
+        working-directory: glTF-CSharp-Loader
+        run: dotnet test glTFLoaderUnitTests/glTFLoaderUnitTests.csproj -c Release
+
+      - name: Pack (validation)
+        working-directory: glTF-CSharp-Loader
+        run: dotnet pack glTFLoader/glTFLoader.csproj -c Release -o artifacts
+
+  publish:
+    name: Publish to NuGet
+    needs: build-and-test
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      # Push to main publishes a preview (<base>-preview.<run_number>). A manual run with
+      # "release" checked publishes the exact version from the csproj; otherwise it also
+      # publishes a preview (useful for validating the NuGet API key on demand).
+      - name: Compute version
+        id: version
+        run: |
+          csproj_version=$(grep -oPm1 '(?<=<Version>)[^<]+' glTFLoader/glTFLoader.csproj)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release }}" = "true" ]; then
+            echo "version=${csproj_version}" >> "$GITHUB_OUTPUT"
+          else
+            base=$(echo "$csproj_version" | sed -E 's/-.*$//')
+            echo "version=${base}-preview.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pack
+        run: dotnet pack glTFLoader/glTFLoader.csproj -c Release -p:ContinuousIntegrationBuild=true -p:Version=${{ steps.version.outputs.version }} -o artifacts
+
+      - name: Push to NuGet
+        if: env.NUGET_API_KEY != ''
+        run: dotnet nuget push "artifacts/*.nupkg" -k "$NUGET_API_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Warn if NuGet API key is missing
+        if: env.NUGET_API_KEY == ''
+        run: echo "::warning::NUGET_API_KEY secret is not set - packed ${{ steps.version.outputs.version }} but did not publish."
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg
+          path: artifacts/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Pack (validation)
         working-directory: glTF-CSharp-Loader
-        run: dotnet pack glTFLoader/glTFLoader.csproj -c Release -o artifacts
+        run: dotnet pack glTFLoader/glTFLoader.csproj -c Release -p:GeneratePackageOnBuild=false -o artifacts
 
   publish:
     name: Publish to NuGet
@@ -107,7 +107,7 @@ jobs:
           fi
 
       - name: Pack
-        run: dotnet pack glTFLoader/glTFLoader.csproj -c Release -p:ContinuousIntegrationBuild=true -p:Version=${{ steps.version.outputs.version }} -o artifacts
+        run: dotnet pack glTFLoader/glTFLoader.csproj -c Release -p:ContinuousIntegrationBuild=true -p:GeneratePackageOnBuild=false -p:Version=${{ steps.version.outputs.version }} -o artifacts
 
       - name: Push to NuGet
         if: env.NUGET_API_KEY != ''

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/
 obj/
 packages/
+artifacts/
 TestResults/
 TestResult.xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0]
+
+### Added
+- Support for the `KHR_animation_pointer` extension (`pointer` animation channel target path).
+- Support for the `EXT_texture_webp` extension (`image/webp` images).
+- GitHub Actions CI that builds and tests on every push and pull request.
+- Automated NuGet publishing: preview packages (`X.Y.Z-preview.<run>`) on push to `main`, and manual preview/release publishing via workflow dispatch.
+
+### Changed
+- **Breaking:** Migrated JSON serialization from Newtonsoft.Json to System.Text.Json. Extension values in `Extensions` are now `System.Text.Json.JsonElement` rather than Newtonsoft `JObject`.
+- **Breaking:** Target frameworks are now `netstandard2.0` and `net8.0` (previously `netstandard1.3`).
+- Schema classes now share common base classes (`GltfProperty`, `GltfChildOfRootProperty`).
+- Mime-type detection from image URIs is now case-insensitive.
+- Unit tests load models from the `glTF-Sample-Assets` repository (previously the deprecated `glTF-Sample-Models`).
+
+## [1.1.4-alpha]
+- Last version published to NuGet, using Newtonsoft.Json and targeting `netstandard1.3`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a C# reference loader for glTF.  It's as simple to use as `Interface.Loa
 
 ### Prerequisites
 
-This solution requires access to the glTF schema to compile and the sample models to test. It assumes that the glTF and glTF-Sample-Models repos have been cloned under the same root directory that the glTF-CSharp-Loader repo was cloned.
+This solution requires access to the glTF schema to compile and the sample models to test. It assumes that the glTF and glTF-Sample-Assets repos have been cloned under the same root directory that the glTF-CSharp-Loader repo was cloned.
 
 ```
 repos
@@ -12,10 +12,10 @@ repos
 |   +-- README.md
 +-- glTF-CSharp-Loader
 |   +-- README.md
-+-- glTF-Sample-Models
++-- glTF-Sample-Assets
 |   +-- README.md
 ```
 
 ### Building
 
-To build the project, load the CSharp.sln solution.  Click "Start". This will build glTFLoader_Shared, GeneratorLib, and Generator. It will then run the Generator. The generator reads the .spec files defining the glTF standard and generates a set of classes that will be used as the schema for loading your models. The glTFLoader project can now be built.  You will need glTFLoader.dll and glTFLoader_shared.dll in order to use the loader in any subsequent project.
+To build the project, load the GltfLoader.sln solution.  Click "Start". This will build glTFLoader_Shared, GeneratorLib, and Generator. It will then run the Generator. The generator reads the .spec files defining the glTF standard and generates a set of classes that will be used as the schema for loading your models. The glTFLoader project can now be built.  You will need glTFLoader.dll and glTFLoader_shared.dll in order to use the loader in any subsequent project.

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -21,6 +21,7 @@ namespace glTFLoader
 
         const string EMBEDDEDPNG = "data:image/png;base64,";
         const string EMBEDDEDJPEG = "data:image/jpeg;base64,";
+        const string EMBEDDEDWEBP = "data:image/webp;base64,";
 
         private static readonly Encoding DefaultStreamWriterEncoding = new UTF8Encoding(
             encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
@@ -294,6 +295,7 @@ namespace glTFLoader
 
             if (image.Uri.StartsWith(EMBEDDEDPNG)) content = image.Uri.Substring(EMBEDDEDPNG.Length);
             if (image.Uri.StartsWith(EMBEDDEDJPEG)) content = image.Uri.Substring(EMBEDDEDJPEG.Length);
+            if (image.Uri.StartsWith(EMBEDDEDWEBP)) content = image.Uri.Substring(EMBEDDEDWEBP.Length);
 
             var bytes = Convert.FromBase64String(content);
             return new MemoryStream(bytes);
@@ -598,7 +600,12 @@ namespace glTFLoader
                         {
                             imageBufferViewIndices.Add(image.BufferView.Value);
 
-                            var fileExtension = image.MimeType == Image.MimeTypeEnum.image_jpeg ? "jpg" : "png";
+                            var fileExtension = image.MimeType switch
+                            {
+                                Image.MimeTypeEnum.image_jpeg => "jpg",
+                                Image.MimeTypeEnum.image_webp => "webp",
+                                _ => "png",
+                            };
                             var fileName = $"{inputFileName}_image{index}.{fileExtension}";
 
                             using (var fileStream = File.Create(Path.Combine(outputDirectoryPath, fileName)))
@@ -739,6 +746,11 @@ namespace glTFLoader
             if (uri.StartsWith("data:image/jpeg;base64,") || uri.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) || uri.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase))
             {
                 return Image.MimeTypeEnum.image_jpeg;
+            }
+
+            if (uri.StartsWith("data:image/webp;base64,") || uri.EndsWith(".webp", StringComparison.OrdinalIgnoreCase))
+            {
+                return Image.MimeTypeEnum.image_webp;
             }
 
             throw new InvalidOperationException("Unable to determine mime type from uri");

--- a/glTFLoader/README.md
+++ b/glTFLoader/README.md
@@ -1,0 +1,34 @@
+# glTF2Loader
+
+A C# reference loader for [glTF 2.0](https://www.khronos.org/gltf/), the runtime 3D asset format from the Khronos Group.
+
+## Installation
+
+```
+dotnet add package glTF2Loader
+```
+
+## Usage
+
+```csharp
+using glTFLoader;
+
+// Load a .gltf or .glb model.
+var model = Interface.LoadModel("model.gltf");
+
+// Access the deserialized glTF properties.
+foreach (var mesh in model.Meshes)
+{
+    // ...
+}
+```
+
+The loader also supports saving models, packing/unpacking `.glb` binary files, and reading buffers and images. See the `glTFLoaderUnitTests` project in the repository for more examples.
+
+## Changelog
+
+See [CHANGELOG.md](https://github.com/KhronosGroup/glTF-CSharp-Loader/blob/main/CHANGELOG.md) for the release history.
+
+## License
+
+See [LICENSE.md](https://github.com/KhronosGroup/glTF-CSharp-Loader/blob/main/LICENSE.md).

--- a/glTFLoader/Schema/AnimationChannelTarget.cs
+++ b/glTFLoader/Schema/AnimationChannelTarget.cs
@@ -69,6 +69,9 @@ namespace glTFLoader.Schema {
             scale,
             
             weights,
+            
+            // Added manually to support the KHR_animation_pointer extension (not defined in the core schema).
+            pointer,
         }
     }
 }

--- a/glTFLoader/Schema/Image.cs
+++ b/glTFLoader/Schema/Image.cs
@@ -94,6 +94,10 @@ namespace glTFLoader.Schema {
             
             [System.Text.Json.Serialization.JsonStringEnumMemberName("image/png")]
             image_png,
+            
+            // Added manually to support the EXT_texture_webp extension (not defined in the core schema).
+            [System.Text.Json.Serialization.JsonStringEnumMemberName("image/webp")]
+            image_webp,
         }
     }
 }

--- a/glTFLoader/glTFLoader.csproj
+++ b/glTFLoader/glTFLoader.csproj
@@ -8,14 +8,20 @@
     <Product>glTF2Loader</Product>
     <PackageId>glTF2Loader</PackageId>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageProjectUrl>https://github.com/KhronosGroup/glTF-CSharp-Loader/blob/master/README.md</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/KhronosGroup/glTF-CSharp-Loader/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/KhronosGroup/glTF-CSharp-Loader/blob/main/README.md</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/KhronosGroup/glTF-CSharp-Loader/blob/main/LICENSE.md</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/KhronosGroup/glTF-CSharp-Loader</RepositoryUrl>
     <PackageIconUrl>https://github.com/KhronosGroup/glTF/blob/master/specification/figures/gltf.png</PackageIconUrl>
     <PackageTags>glTF loader C#</PackageTags>
-    <Version>1.1.4-alpha</Version>
+    <Version>2.0.0</Version>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>See https://github.com/KhronosGroup/glTF-CSharp-Loader/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="9.0.5" />

--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -158,24 +158,30 @@ namespace glTFLoaderUnitTests
         [InlineData("glTF-Binary")]
         public void UnpackBinary(string subdirectory)
         {
-            string gltfUnpackDir = Path.Combine(Path.GetTempPath(), "glTF-unpacked");
+            // Use a unique directory so concurrent test runs (e.g. the net462 and net8.0
+            // target frameworks running in parallel) do not share and delete each other's output.
+            string gltfUnpackDir = Path.Combine(Path.GetTempPath(), "glTF-unpacked-" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(gltfUnpackDir);
 
-            foreach (var file in GetTestFiles(subdirectory))
+            try
             {
-                var gltf = TestLoadFile(file);
+                foreach (var file in GetTestFiles(subdirectory))
+                {
+                    var gltf = TestLoadFile(file);
 
-                string modelName = Path.GetFileName(file);
-                string gltfUnpackDirModel = Path.Combine(gltfUnpackDir, modelName);
-                Directory.CreateDirectory(gltfUnpackDirModel);
+                    string modelName = Path.GetFileName(file);
+                    string gltfUnpackDirModel = Path.Combine(gltfUnpackDir, modelName);
+                    Directory.CreateDirectory(gltfUnpackDirModel);
 
-                Interface.Unpack(file, gltfUnpackDirModel);
+                    Interface.Unpack(file, gltfUnpackDirModel);
 
-                TestLoadFile(Path.Combine(gltfUnpackDirModel, Path.ChangeExtension(modelName, "gltf")));
-
-
+                    TestLoadFile(Path.Combine(gltfUnpackDirModel, Path.ChangeExtension(modelName, "gltf")));
+                }
             }
-            Directory.Delete(gltfUnpackDir, true);
+            finally
+            {
+                Directory.Delete(gltfUnpackDir, true);
+            }
         }
 
 

--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -10,7 +10,7 @@ namespace glTFLoaderUnitTests
 {
     public class SampleModelsTest
     {
-        private const string RelativePathToSchemaDir = @"..\..\..\..\..\glTF-Sample-Models\2.0\";
+        private const string RelativePathToSchemaDir = @"..\..\..\..\..\glTF-Sample-Assets\Models\";
         private string AbsolutePathToSchemaDir;
 
         public SampleModelsTest()
@@ -66,6 +66,7 @@ namespace glTFLoaderUnitTests
 
                             if (header == 0x474e5089) continue; // PNG
                             if ((header & 0xffff) == 0xd8ff) continue; // JPEG
+                            if (header == 0x46464952) continue; // WebP (RIFF)
 
                             Assert.Fail($"Invalid image in Image index {i}");
                         }


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## What this adds

A GitHub Actions workflow that builds and tests on every push/PR to `main`, publishes a preview `glTF2Loader` package to nuget.org on every push to `main`, and supports manual publishing via `workflow_dispatch`.

- **build-and-test** (windows): runs the generator unit tests (shallow `KhronosGroup/glTF` checkout) and the loader unit tests (shallow, cached `KhronosGroup/glTF-Sample-Assets` checkout), then validates packaging. It builds the individual projects rather than the full solution so the code generator does not regenerate the checked-in schema during CI.
- **publish** (ubuntu): on push to `main`, packs `glTFLoader` as `<base>-preview.<run_number>` and pushes to nuget.org with `--skip-duplicate`. A manual run publishes another preview, or with **release** checked, the exact version from the csproj. Uses the `NUGET_API_KEY` secret; if unset, it packs and uploads the `.nupkg` as an artifact but skips the push.

## Sample assets + loader changes

The loader tests move from the deprecated `glTF-Sample-Models` to the current `glTF-Sample-Assets`. Six of its models use extensions the loader did not model, so the loader is extended to load them:

- **KHR_animation_pointer**: accept `"pointer"` as an animation channel target `path`.
- **EXT_texture_webp**: accept `image/webp` images — mime detection from `.webp`/`data:image/webp` uris, embedded webp decoding, and `.webp` output when unpacking.

The extension objects themselves already round-trip through the generic `Extensions` dictionary; only these two core enum values (added by hand to the generated schema files, since they come from extension schemas rather than the core schema the generator reads) and the webp image plumbing were missing.

The README's sibling-repo references and stale solution name are updated to match.
