### PR TITLE
Support open string enums (KHR_animation_pointer, EXT_texture_webp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Breaking:** Migrated JSON serialization from Newtonsoft.Json to System.Text.Json. Extension values in `Extensions` are now `System.Text.Json.JsonElement` rather than Newtonsoft `JObject`.
 - **Breaking:** Target frameworks are now `netstandard2.0` and `net8.0` (previously `netstandard1.3`).
-- **Breaking:** Properties backed by open string enums in the schema (`Accessor.Type`, `AnimationChannelTarget.Path`, `AnimationSampler.Interpolation`, `Camera.Type`, `Image.MimeType`, `Material.AlphaMode`) are now generated as "smart enum" structs instead of C# enums. The known values remain available as static readonly fields (e.g. `Material.AlphaModeEnum.OPAQUE`), so existing equality comparisons keep working, but any string is now accepted so extension-defined values round-trip instead of throwing.
+- **Breaking:** Properties backed by open string enums (`Accessor.Type`, `AnimationChannelTarget.Path`, `AnimationSampler.Interpolation`, `Camera.Type`, `Image.MimeType`, `Material.AlphaMode`) are now generated as "smart enum" structs instead of C# enums. Known values remain as static readonly fields (e.g. `Material.AlphaModeEnum.OPAQUE`), so equality comparisons and assignments still work, and any string (including extension-defined values) now round-trips instead of throwing. `switch` statements over these values must become `if`/`else` (or switch on `.Value`).
 - Schema classes now share common base classes (`GltfProperty`, `GltfChildOfRootProperty`).
 - Mime-type detection from image URIs is now case-insensitive.
 - Unit tests load models from the `glTF-Sample-Assets` repository (previously the deprecated `glTF-Sample-Models`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0]
 
 ### Added
+- Support for glTF extensions that add values to open string enums, including `KHR_animation_pointer` (animation channel target path `"pointer"`) and `EXT_texture_webp` (`image/webp` images).
 - GitHub Actions CI that builds and tests on every push and pull request.
 - Automated NuGet publishing: preview packages (`X.Y.Z-preview.<run>`) on push to `main`, and manual preview/release publishing via workflow dispatch.
 
 ### Changed
 - **Breaking:** Migrated JSON serialization from Newtonsoft.Json to System.Text.Json. Extension values in `Extensions` are now `System.Text.Json.JsonElement` rather than Newtonsoft `JObject`.
 - **Breaking:** Target frameworks are now `netstandard2.0` and `net8.0` (previously `netstandard1.3`).
+- **Breaking:** Properties backed by open string enums in the schema (`Accessor.Type`, `AnimationChannelTarget.Path`, `AnimationSampler.Interpolation`, `Camera.Type`, `Image.MimeType`, `Material.AlphaMode`) are now generated as "smart enum" structs instead of C# enums. The known values remain available as static readonly fields (e.g. `Material.AlphaModeEnum.OPAQUE`), so existing equality comparisons keep working, but any string is now accepted so extension-defined values round-trip instead of throwing.
 - Schema classes now share common base classes (`GltfProperty`, `GltfChildOfRootProperty`).
 - Mime-type detection from image URIs is now case-insensitive.
 - Unit tests load models from the `glTF-Sample-Assets` repository (previously the deprecated `glTF-Sample-Models`).

--- a/GeneratorLib/CodeGenerator.cs
+++ b/GeneratorLib/CodeGenerator.cs
@@ -252,7 +252,9 @@ namespace KhronosGroup.Gltf.Generator
             {
                 foreach (var nestedEnum in generatedClass.Members.OfType<CodeTypeDeclaration>())
                 {
-                    if (nestedEnum.IsEnum)
+                    // Open string enums are generated as structs (smart enums); like enums, colliding
+                    // simple names must be disambiguated with a distinct TypeInfoPropertyName.
+                    if (nestedEnum.IsEnum || nestedEnum.IsStruct)
                     {
                         nestedEnums.Add(new KeyValuePair<string, string>(generatedClass.Name, nestedEnum.Name));
                     }

--- a/GeneratorLib/SingleValueCodegenTypeFactory.cs
+++ b/GeneratorLib/SingleValueCodegenTypeFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.CodeDom;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using KhronosGroup.Gltf.Generator.JsonSchema;
@@ -88,6 +89,11 @@ namespace KhronosGroup.Gltf.Generator
             {
                 if (schema.Enum != null)
                 {
+                    if (schema.IsOpenStringEnum)
+                    {
+                        return MakeOpenStringEnumType(name, schema, returnType);
+                    }
+
                     var enumType = GenStringEnumType(name, schema);
                     returnType.Attributes.Add(
                         new CodeAttributeDeclaration("System.Text.Json.Serialization.JsonConverter", 
@@ -321,6 +327,121 @@ namespace KhronosGroup.Gltf.Generator
             }
 
             return enumType;
+        }
+
+        // Open string enums (schemas whose anyOf permits an arbitrary string in addition to the
+        // known constants) are generated as a "smart enum" struct instead of a strict C# enum.
+        // The struct exposes the known values as static readonly fields but round-trips any string,
+        // so values introduced by extensions (e.g. KHR_animation_pointer's "pointer" or
+        // EXT_texture_webp's "image/webp") load and save without error.
+        private static CodegenType MakeOpenStringEnumType(string name, Schema schema, CodegenType returnType)
+        {
+            var structName = $"{name}Enum";
+            returnType.AdditionalMembers.Add(GenStringEnumStruct(structName, schema));
+
+            if (schema.HasDefaultValue())
+            {
+                returnType.CodeType = new CodeTypeReference(structName);
+                returnType.DefaultValue = new CodeFieldReferenceExpression(
+                    new CodeTypeReferenceExpression(structName), SanitizeEnumMemberName((string)schema.Default));
+                returnType.AdditionalMembers.Add(Helpers.CreateMethodThatChecksIfTheValueOfAMemberIsNotEqualToAnotherExpression(name, returnType.DefaultValue));
+                return returnType;
+            }
+
+            if (!schema.IsRequired)
+            {
+                returnType.CodeType = new CodeTypeReference(typeof(Nullable<>));
+                returnType.CodeType.TypeArguments.Add(new CodeTypeReference(structName));
+                returnType.AdditionalMembers.Add(Helpers.CreateMethodThatChecksIfTheValueOfAMemberIsNotEqualToAnotherExpression(name, new CodePrimitiveExpression(null)));
+                return returnType;
+            }
+
+            returnType.CodeType = new CodeTypeReference(structName);
+            return returnType;
+        }
+
+        private static string SanitizeEnumMemberName(string value)
+        {
+            return value.Contains('/') ? Regex.Replace(value, "/", "_") : value;
+        }
+
+        public static CodeTypeDeclaration GenStringEnumStruct(string structName, Schema schema)
+        {
+            var converterName = $"{structName}Converter";
+
+            var structType = new CodeTypeDeclaration(structName)
+            {
+                IsStruct = true,
+                Attributes = MemberAttributes.Public,
+            };
+            structType.CustomAttributes.Add(new CodeAttributeDeclaration(
+                "System.Text.Json.Serialization.JsonConverter",
+                new CodeAttributeArgument(new CodeTypeOfExpression(converterName))));
+            structType.BaseTypes.Add(new CodeTypeReference($"System.IEquatable<{structName}>"));
+
+            var body = new StringBuilder();
+            body.AppendLine("private readonly string m_value;");
+            body.AppendLine();
+            body.AppendLine($"public {structName}(string value) {{");
+            body.AppendLine("    this.m_value = value;");
+            body.AppendLine("}");
+            body.AppendLine();
+            foreach (var value in schema.Enum)
+            {
+                var memberName = SanitizeEnumMemberName((string)value);
+                body.AppendLine($"public static readonly {structName} {memberName} = new {structName}(\"{value}\");");
+            }
+            body.AppendLine();
+            body.AppendLine("public string Value {");
+            body.AppendLine("    get { return this.m_value; }");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine("public override string ToString() {");
+            body.AppendLine("    return this.m_value;");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine($"public bool Equals({structName} other) {{");
+            body.AppendLine("    return string.Equals(this.m_value, other.m_value, System.StringComparison.Ordinal);");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine("public override bool Equals(object obj) {");
+            body.AppendLine($"    return ((obj is {structName}) && this.Equals((({structName})(obj))));");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine("public override int GetHashCode() {");
+            body.AppendLine("    return ((this.m_value == null) ? 0 : this.m_value.GetHashCode());");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine($"public static bool operator ==({structName} left, {structName} right) {{");
+            body.AppendLine("    return left.Equals(right);");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine($"public static bool operator !=({structName} left, {structName} right) {{");
+            body.AppendLine("    return (left.Equals(right) == false);");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine($"public static implicit operator string({structName} value) {{");
+            body.AppendLine("    return value.m_value;");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine($"public static implicit operator {structName}(string value) {{");
+            body.AppendLine($"    return new {structName}(value);");
+            body.AppendLine("}");
+            body.AppendLine();
+            body.AppendLine($"public class {converterName} : System.Text.Json.Serialization.JsonConverter<{structName}> {{");
+            body.AppendLine($"    public override {structName} Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) {{");
+            body.AppendLine("        if (reader.TokenType != System.Text.Json.JsonTokenType.String) {");
+            body.AppendLine($"            throw new System.Text.Json.JsonException(\"Expected a string value for {structName}.\");");
+            body.AppendLine("        }");
+            body.AppendLine($"        return new {structName}(reader.GetString());");
+            body.AppendLine("    }");
+            body.AppendLine($"    public override void Write(System.Text.Json.Utf8JsonWriter writer, {structName} value, System.Text.Json.JsonSerializerOptions options) {{");
+            body.AppendLine("        writer.WriteStringValue(value.m_value);");
+            body.AppendLine("    }");
+            body.AppendLine("}");
+
+            structType.Members.Add(new CodeSnippetTypeMember(body.ToString()));
+            return structType;
         }
 
         public static CodeTypeDeclaration GenIntEnumType(string name, Schema schema)

--- a/GeneratorSchema/Schema.cs
+++ b/GeneratorSchema/Schema.cs
@@ -97,6 +97,10 @@ namespace KhronosGroup.Gltf.Generator.JsonSchema
 
         public IList<object> Enum { get; set; }
 
+        // True when the enum's anyOf includes a bare { "type": "string" } fallback, meaning the
+        // schema permits arbitrary strings (an "open" enum, e.g. extensions may add values).
+        public bool IsOpenStringEnum { get; set; }
+
         [JsonProperty("gltf_enumNames")]
         public IList<string> EnumNames { get; set; }
 
@@ -191,7 +195,14 @@ namespace KhronosGroup.Gltf.Generator.JsonSchema
                     {
                         this.Type = new List<TypeReference>();
                     }
-                    this.Type.Add(new TypeReference { IsReference = false, Name = dict["type"].ToString() });
+                    var typeName = dict["type"].ToString();
+                    this.Type.Add(new TypeReference { IsReference = false, Name = typeName });
+                    if (typeName == "string")
+                    {
+                        // A bare { "type": "string" } alongside "const" values marks an open enum:
+                        // the known values are documented, but any string is permitted.
+                        this.IsOpenStringEnum = true;
+                    }
                     break;
                 }
             }

--- a/GeneratorSchema/Schema.cs
+++ b/GeneratorSchema/Schema.cs
@@ -197,10 +197,11 @@ namespace KhronosGroup.Gltf.Generator.JsonSchema
                     }
                     var typeName = dict["type"].ToString();
                     this.Type.Add(new TypeReference { IsReference = false, Name = typeName });
-                    if (typeName == "string")
+                    if (typeName == "string" && dict.Count == 1)
                     {
-                        // A bare { "type": "string" } alongside "const" values marks an open enum:
-                        // the known values are documented, but any string is permitted.
+                        // Only a bare { "type": "string" } (no other constraints such as "pattern"
+                        // or "format") alongside "const" values marks an open enum: the known values
+                        // are documented, but any string is permitted.
                         this.IsOpenStringEnum = true;
                     }
                     break;

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -291,12 +291,15 @@ namespace glTFLoader
 
         private static Stream OpenEmbeddedImage(Image image)
         {
-            string content = null;
+            const string base64Marker = ";base64,";
 
-            if (image.Uri.StartsWith(EMBEDDEDPNG)) content = image.Uri.Substring(EMBEDDEDPNG.Length);
-            if (image.Uri.StartsWith(EMBEDDEDJPEG)) content = image.Uri.Substring(EMBEDDEDJPEG.Length);
-            if (image.Uri.StartsWith(EMBEDDEDWEBP)) content = image.Uri.Substring(EMBEDDEDWEBP.Length);
+            var markerIndex = image.Uri.IndexOf(base64Marker, StringComparison.Ordinal);
+            if (markerIndex < 0)
+            {
+                throw new InvalidOperationException($"Unsupported embedded image URI '{image.Uri}': expected a base64-encoded data URI.");
+            }
 
+            var content = image.Uri.Substring(markerIndex + base64Marker.Length);
             var bytes = Convert.FromBase64String(content);
             return new MemoryStream(bytes);
         }
@@ -601,17 +604,18 @@ namespace glTFLoader
                             imageBufferViewIndices.Add(image.BufferView.Value);
 
                             string fileExtension;
-                            if (image.MimeType == Image.MimeTypeEnum.image_jpeg)
+                            var mimeType = image.MimeType.HasValue ? image.MimeType.Value.ToString() : null;
+                            if (mimeType == "image/jpeg")
                             {
                                 fileExtension = "jpg";
                             }
-                            else if (image.MimeType == new Image.MimeTypeEnum("image/webp"))
+                            else if (!string.IsNullOrEmpty(mimeType) && mimeType.StartsWith("image/", StringComparison.Ordinal))
                             {
-                                fileExtension = "webp";
+                                fileExtension = mimeType.Substring("image/".Length);
                             }
                             else
                             {
-                                fileExtension = "png";
+                                fileExtension = "bin";
                             }
                             var fileName = $"{inputFileName}_image{index}.{fileExtension}";
 
@@ -745,17 +749,17 @@ namespace glTFLoader
                 return null;
             }
 
-            if (uri.StartsWith("data:image/png;base64,") || uri.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
+            if (uri.StartsWith(EMBEDDEDPNG, StringComparison.Ordinal) || uri.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
             {
                 return Image.MimeTypeEnum.image_png;
             }
 
-            if (uri.StartsWith("data:image/jpeg;base64,") || uri.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) || uri.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase))
+            if (uri.StartsWith(EMBEDDEDJPEG, StringComparison.Ordinal) || uri.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) || uri.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase))
             {
                 return Image.MimeTypeEnum.image_jpeg;
             }
 
-            if (uri.StartsWith("data:image/webp;base64,") || uri.EndsWith(".webp", StringComparison.OrdinalIgnoreCase))
+            if (uri.StartsWith(EMBEDDEDWEBP, StringComparison.Ordinal) || uri.EndsWith(".webp", StringComparison.OrdinalIgnoreCase))
             {
                 return new Image.MimeTypeEnum("image/webp");
             }

--- a/glTFLoader/Interface.cs
+++ b/glTFLoader/Interface.cs
@@ -21,6 +21,7 @@ namespace glTFLoader
 
         const string EMBEDDEDPNG = "data:image/png;base64,";
         const string EMBEDDEDJPEG = "data:image/jpeg;base64,";
+        const string EMBEDDEDWEBP = "data:image/webp;base64,";
 
         private static readonly Encoding DefaultStreamWriterEncoding = new UTF8Encoding(
             encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
@@ -294,6 +295,7 @@ namespace glTFLoader
 
             if (image.Uri.StartsWith(EMBEDDEDPNG)) content = image.Uri.Substring(EMBEDDEDPNG.Length);
             if (image.Uri.StartsWith(EMBEDDEDJPEG)) content = image.Uri.Substring(EMBEDDEDJPEG.Length);
+            if (image.Uri.StartsWith(EMBEDDEDWEBP)) content = image.Uri.Substring(EMBEDDEDWEBP.Length);
 
             var bytes = Convert.FromBase64String(content);
             return new MemoryStream(bytes);
@@ -598,7 +600,19 @@ namespace glTFLoader
                         {
                             imageBufferViewIndices.Add(image.BufferView.Value);
 
-                            var fileExtension = image.MimeType == Image.MimeTypeEnum.image_jpeg ? "jpg" : "png";
+                            string fileExtension;
+                            if (image.MimeType == Image.MimeTypeEnum.image_jpeg)
+                            {
+                                fileExtension = "jpg";
+                            }
+                            else if (image.MimeType == new Image.MimeTypeEnum("image/webp"))
+                            {
+                                fileExtension = "webp";
+                            }
+                            else
+                            {
+                                fileExtension = "png";
+                            }
                             var fileName = $"{inputFileName}_image{index}.{fileExtension}";
 
                             using (var fileStream = File.Create(Path.Combine(outputDirectoryPath, fileName)))
@@ -739,6 +753,11 @@ namespace glTFLoader
             if (uri.StartsWith("data:image/jpeg;base64,") || uri.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) || uri.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase))
             {
                 return Image.MimeTypeEnum.image_jpeg;
+            }
+
+            if (uri.StartsWith("data:image/webp;base64,") || uri.EndsWith(".webp", StringComparison.OrdinalIgnoreCase))
+            {
+                return new Image.MimeTypeEnum("image/webp");
             }
 
             throw new InvalidOperationException("Unable to determine mime type from uri");

--- a/glTFLoader/Schema/Accessor.cs
+++ b/glTFLoader/Schema/Accessor.cs
@@ -138,7 +138,6 @@ namespace glTFLoader.Schema {
         /// <summary>
         /// Specifies if the accessor's elements are scalars, vectors, or matrices.
         /// </summary>
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<TypeEnum>))]
         [System.Text.Json.Serialization.JsonRequired()]
         [System.Text.Json.Serialization.JsonPropertyName("type")]
         public TypeEnum Type {
@@ -254,21 +253,71 @@ namespace glTFLoader.Schema {
             FLOAT = 5126,
         }
         
-        public enum TypeEnum {
+        [System.Text.Json.Serialization.JsonConverter(typeof(TypeEnumConverter))]
+        public struct TypeEnum : System.IEquatable<TypeEnum> {
             
-            SCALAR,
-            
-            VEC2,
-            
-            VEC3,
-            
-            VEC4,
-            
-            MAT2,
-            
-            MAT3,
-            
-            MAT4,
+private readonly string m_value;
+
+public TypeEnum(string value) {
+    this.m_value = value;
+}
+
+public static readonly TypeEnum SCALAR = new TypeEnum("SCALAR");
+public static readonly TypeEnum VEC2 = new TypeEnum("VEC2");
+public static readonly TypeEnum VEC3 = new TypeEnum("VEC3");
+public static readonly TypeEnum VEC4 = new TypeEnum("VEC4");
+public static readonly TypeEnum MAT2 = new TypeEnum("MAT2");
+public static readonly TypeEnum MAT3 = new TypeEnum("MAT3");
+public static readonly TypeEnum MAT4 = new TypeEnum("MAT4");
+
+public string Value {
+    get { return this.m_value; }
+}
+
+public override string ToString() {
+    return this.m_value;
+}
+
+public bool Equals(TypeEnum other) {
+    return string.Equals(this.m_value, other.m_value, System.StringComparison.Ordinal);
+}
+
+public override bool Equals(object obj) {
+    return ((obj is TypeEnum) && this.Equals(((TypeEnum)(obj))));
+}
+
+public override int GetHashCode() {
+    return ((this.m_value == null) ? 0 : this.m_value.GetHashCode());
+}
+
+public static bool operator ==(TypeEnum left, TypeEnum right) {
+    return left.Equals(right);
+}
+
+public static bool operator !=(TypeEnum left, TypeEnum right) {
+    return (left.Equals(right) == false);
+}
+
+public static implicit operator string(TypeEnum value) {
+    return value.m_value;
+}
+
+public static implicit operator TypeEnum(string value) {
+    return new TypeEnum(value);
+}
+
+public class TypeEnumConverter : System.Text.Json.Serialization.JsonConverter<TypeEnum> {
+    public override TypeEnum Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) {
+        if (reader.TokenType != System.Text.Json.JsonTokenType.String) {
+            throw new System.Text.Json.JsonException("Expected a string value for TypeEnum.");
+        }
+        return new TypeEnum(reader.GetString());
+    }
+    public override void Write(System.Text.Json.Utf8JsonWriter writer, TypeEnum value, System.Text.Json.JsonSerializerOptions options) {
+        writer.WriteStringValue(value.m_value);
+    }
+}
+
         }
     }
 }

--- a/glTFLoader/Schema/AnimationChannelTarget.cs
+++ b/glTFLoader/Schema/AnimationChannelTarget.cs
@@ -43,7 +43,6 @@ namespace glTFLoader.Schema {
         /// <summary>
         /// The name of the node's TRS property to animate, or the `"weights"` of the Morph Targets it instantiates. For the `"translation"` property, the values that are provided by the sampler are the translation along the X, Y, and Z axes. For the `"rotation"` property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the `"scale"` property, the values are the scaling factors along the X, Y, and Z axes.
         /// </summary>
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<PathEnum>))]
         [System.Text.Json.Serialization.JsonRequired()]
         [System.Text.Json.Serialization.JsonPropertyName("path")]
         public PathEnum Path {
@@ -60,15 +59,68 @@ namespace glTFLoader.Schema {
                         == false);
         }
         
-        public enum PathEnum {
+        [System.Text.Json.Serialization.JsonConverter(typeof(PathEnumConverter))]
+        public struct PathEnum : System.IEquatable<PathEnum> {
             
-            translation,
-            
-            rotation,
-            
-            scale,
-            
-            weights,
+private readonly string m_value;
+
+public PathEnum(string value) {
+    this.m_value = value;
+}
+
+public static readonly PathEnum translation = new PathEnum("translation");
+public static readonly PathEnum rotation = new PathEnum("rotation");
+public static readonly PathEnum scale = new PathEnum("scale");
+public static readonly PathEnum weights = new PathEnum("weights");
+
+public string Value {
+    get { return this.m_value; }
+}
+
+public override string ToString() {
+    return this.m_value;
+}
+
+public bool Equals(PathEnum other) {
+    return string.Equals(this.m_value, other.m_value, System.StringComparison.Ordinal);
+}
+
+public override bool Equals(object obj) {
+    return ((obj is PathEnum) && this.Equals(((PathEnum)(obj))));
+}
+
+public override int GetHashCode() {
+    return ((this.m_value == null) ? 0 : this.m_value.GetHashCode());
+}
+
+public static bool operator ==(PathEnum left, PathEnum right) {
+    return left.Equals(right);
+}
+
+public static bool operator !=(PathEnum left, PathEnum right) {
+    return (left.Equals(right) == false);
+}
+
+public static implicit operator string(PathEnum value) {
+    return value.m_value;
+}
+
+public static implicit operator PathEnum(string value) {
+    return new PathEnum(value);
+}
+
+public class PathEnumConverter : System.Text.Json.Serialization.JsonConverter<PathEnum> {
+    public override PathEnum Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) {
+        if (reader.TokenType != System.Text.Json.JsonTokenType.String) {
+            throw new System.Text.Json.JsonException("Expected a string value for PathEnum.");
+        }
+        return new PathEnum(reader.GetString());
+    }
+    public override void Write(System.Text.Json.Utf8JsonWriter writer, PathEnum value, System.Text.Json.JsonSerializerOptions options) {
+        writer.WriteStringValue(value.m_value);
+    }
+}
+
         }
     }
 }

--- a/glTFLoader/Schema/AnimationSampler.cs
+++ b/glTFLoader/Schema/AnimationSampler.cs
@@ -49,7 +49,6 @@ namespace glTFLoader.Schema {
         /// <summary>
         /// Interpolation algorithm.
         /// </summary>
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<InterpolationEnum>))]
         [System.Text.Json.Serialization.JsonPropertyName("interpolation")]
         public InterpolationEnum Interpolation {
             get {
@@ -82,13 +81,67 @@ namespace glTFLoader.Schema {
                         == false);
         }
         
-        public enum InterpolationEnum {
+        [System.Text.Json.Serialization.JsonConverter(typeof(InterpolationEnumConverter))]
+        public struct InterpolationEnum : System.IEquatable<InterpolationEnum> {
             
-            LINEAR,
-            
-            STEP,
-            
-            CUBICSPLINE,
+private readonly string m_value;
+
+public InterpolationEnum(string value) {
+    this.m_value = value;
+}
+
+public static readonly InterpolationEnum LINEAR = new InterpolationEnum("LINEAR");
+public static readonly InterpolationEnum STEP = new InterpolationEnum("STEP");
+public static readonly InterpolationEnum CUBICSPLINE = new InterpolationEnum("CUBICSPLINE");
+
+public string Value {
+    get { return this.m_value; }
+}
+
+public override string ToString() {
+    return this.m_value;
+}
+
+public bool Equals(InterpolationEnum other) {
+    return string.Equals(this.m_value, other.m_value, System.StringComparison.Ordinal);
+}
+
+public override bool Equals(object obj) {
+    return ((obj is InterpolationEnum) && this.Equals(((InterpolationEnum)(obj))));
+}
+
+public override int GetHashCode() {
+    return ((this.m_value == null) ? 0 : this.m_value.GetHashCode());
+}
+
+public static bool operator ==(InterpolationEnum left, InterpolationEnum right) {
+    return left.Equals(right);
+}
+
+public static bool operator !=(InterpolationEnum left, InterpolationEnum right) {
+    return (left.Equals(right) == false);
+}
+
+public static implicit operator string(InterpolationEnum value) {
+    return value.m_value;
+}
+
+public static implicit operator InterpolationEnum(string value) {
+    return new InterpolationEnum(value);
+}
+
+public class InterpolationEnumConverter : System.Text.Json.Serialization.JsonConverter<InterpolationEnum> {
+    public override InterpolationEnum Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) {
+        if (reader.TokenType != System.Text.Json.JsonTokenType.String) {
+            throw new System.Text.Json.JsonException("Expected a string value for InterpolationEnum.");
+        }
+        return new InterpolationEnum(reader.GetString());
+    }
+    public override void Write(System.Text.Json.Utf8JsonWriter writer, InterpolationEnum value, System.Text.Json.JsonSerializerOptions options) {
+        writer.WriteStringValue(value.m_value);
+    }
+}
+
         }
     }
 }

--- a/glTFLoader/Schema/Camera.cs
+++ b/glTFLoader/Schema/Camera.cs
@@ -58,7 +58,6 @@ namespace glTFLoader.Schema {
         /// <summary>
         /// Specifies if the camera uses a perspective or orthographic projection.
         /// </summary>
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<TypeEnum>))]
         [System.Text.Json.Serialization.JsonRequired()]
         [System.Text.Json.Serialization.JsonPropertyName("type")]
         public TypeEnum Type {
@@ -80,11 +79,66 @@ namespace glTFLoader.Schema {
                         == false);
         }
         
-        public enum TypeEnum {
+        [System.Text.Json.Serialization.JsonConverter(typeof(TypeEnumConverter))]
+        public struct TypeEnum : System.IEquatable<TypeEnum> {
             
-            perspective,
-            
-            orthographic,
+private readonly string m_value;
+
+public TypeEnum(string value) {
+    this.m_value = value;
+}
+
+public static readonly TypeEnum perspective = new TypeEnum("perspective");
+public static readonly TypeEnum orthographic = new TypeEnum("orthographic");
+
+public string Value {
+    get { return this.m_value; }
+}
+
+public override string ToString() {
+    return this.m_value;
+}
+
+public bool Equals(TypeEnum other) {
+    return string.Equals(this.m_value, other.m_value, System.StringComparison.Ordinal);
+}
+
+public override bool Equals(object obj) {
+    return ((obj is TypeEnum) && this.Equals(((TypeEnum)(obj))));
+}
+
+public override int GetHashCode() {
+    return ((this.m_value == null) ? 0 : this.m_value.GetHashCode());
+}
+
+public static bool operator ==(TypeEnum left, TypeEnum right) {
+    return left.Equals(right);
+}
+
+public static bool operator !=(TypeEnum left, TypeEnum right) {
+    return (left.Equals(right) == false);
+}
+
+public static implicit operator string(TypeEnum value) {
+    return value.m_value;
+}
+
+public static implicit operator TypeEnum(string value) {
+    return new TypeEnum(value);
+}
+
+public class TypeEnumConverter : System.Text.Json.Serialization.JsonConverter<TypeEnum> {
+    public override TypeEnum Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) {
+        if (reader.TokenType != System.Text.Json.JsonTokenType.String) {
+            throw new System.Text.Json.JsonException("Expected a string value for TypeEnum.");
+        }
+        return new TypeEnum(reader.GetString());
+    }
+    public override void Write(System.Text.Json.Utf8JsonWriter writer, TypeEnum value, System.Text.Json.JsonSerializerOptions options) {
+        writer.WriteStringValue(value.m_value);
+    }
+}
+
         }
     }
 }

--- a/glTFLoader/Schema/Image.cs
+++ b/glTFLoader/Schema/Image.cs
@@ -45,7 +45,6 @@ namespace glTFLoader.Schema {
         /// <summary>
         /// The image's media type. This field **MUST** be defined when `bufferView` is defined.
         /// </summary>
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<MimeTypeEnum>))]
         [System.Text.Json.Serialization.JsonPropertyName("mimeType")]
         public System.Nullable<MimeTypeEnum> MimeType {
             get {
@@ -87,13 +86,66 @@ namespace glTFLoader.Schema {
                         == false);
         }
         
-        public enum MimeTypeEnum {
+        [System.Text.Json.Serialization.JsonConverter(typeof(MimeTypeEnumConverter))]
+        public struct MimeTypeEnum : System.IEquatable<MimeTypeEnum> {
             
-            [System.Text.Json.Serialization.JsonStringEnumMemberName("image/jpeg")]
-            image_jpeg,
-            
-            [System.Text.Json.Serialization.JsonStringEnumMemberName("image/png")]
-            image_png,
+private readonly string m_value;
+
+public MimeTypeEnum(string value) {
+    this.m_value = value;
+}
+
+public static readonly MimeTypeEnum image_jpeg = new MimeTypeEnum("image/jpeg");
+public static readonly MimeTypeEnum image_png = new MimeTypeEnum("image/png");
+
+public string Value {
+    get { return this.m_value; }
+}
+
+public override string ToString() {
+    return this.m_value;
+}
+
+public bool Equals(MimeTypeEnum other) {
+    return string.Equals(this.m_value, other.m_value, System.StringComparison.Ordinal);
+}
+
+public override bool Equals(object obj) {
+    return ((obj is MimeTypeEnum) && this.Equals(((MimeTypeEnum)(obj))));
+}
+
+public override int GetHashCode() {
+    return ((this.m_value == null) ? 0 : this.m_value.GetHashCode());
+}
+
+public static bool operator ==(MimeTypeEnum left, MimeTypeEnum right) {
+    return left.Equals(right);
+}
+
+public static bool operator !=(MimeTypeEnum left, MimeTypeEnum right) {
+    return (left.Equals(right) == false);
+}
+
+public static implicit operator string(MimeTypeEnum value) {
+    return value.m_value;
+}
+
+public static implicit operator MimeTypeEnum(string value) {
+    return new MimeTypeEnum(value);
+}
+
+public class MimeTypeEnumConverter : System.Text.Json.Serialization.JsonConverter<MimeTypeEnum> {
+    public override MimeTypeEnum Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) {
+        if (reader.TokenType != System.Text.Json.JsonTokenType.String) {
+            throw new System.Text.Json.JsonException("Expected a string value for MimeTypeEnum.");
+        }
+        return new MimeTypeEnum(reader.GetString());
+    }
+    public override void Write(System.Text.Json.Utf8JsonWriter writer, MimeTypeEnum value, System.Text.Json.JsonSerializerOptions options) {
+        writer.WriteStringValue(value.m_value);
+    }
+}
+
         }
     }
 }

--- a/glTFLoader/Schema/Material.cs
+++ b/glTFLoader/Schema/Material.cs
@@ -142,7 +142,6 @@ namespace glTFLoader.Schema {
         /// <summary>
         /// The alpha rendering mode of the material.
         /// </summary>
-        [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter<AlphaModeEnum>))]
         [System.Text.Json.Serialization.JsonPropertyName("alphaMode")]
         public AlphaModeEnum AlphaMode {
             get {
@@ -224,13 +223,67 @@ namespace glTFLoader.Schema {
                         == false);
         }
         
-        public enum AlphaModeEnum {
+        [System.Text.Json.Serialization.JsonConverter(typeof(AlphaModeEnumConverter))]
+        public struct AlphaModeEnum : System.IEquatable<AlphaModeEnum> {
             
-            OPAQUE,
-            
-            MASK,
-            
-            BLEND,
+private readonly string m_value;
+
+public AlphaModeEnum(string value) {
+    this.m_value = value;
+}
+
+public static readonly AlphaModeEnum OPAQUE = new AlphaModeEnum("OPAQUE");
+public static readonly AlphaModeEnum MASK = new AlphaModeEnum("MASK");
+public static readonly AlphaModeEnum BLEND = new AlphaModeEnum("BLEND");
+
+public string Value {
+    get { return this.m_value; }
+}
+
+public override string ToString() {
+    return this.m_value;
+}
+
+public bool Equals(AlphaModeEnum other) {
+    return string.Equals(this.m_value, other.m_value, System.StringComparison.Ordinal);
+}
+
+public override bool Equals(object obj) {
+    return ((obj is AlphaModeEnum) && this.Equals(((AlphaModeEnum)(obj))));
+}
+
+public override int GetHashCode() {
+    return ((this.m_value == null) ? 0 : this.m_value.GetHashCode());
+}
+
+public static bool operator ==(AlphaModeEnum left, AlphaModeEnum right) {
+    return left.Equals(right);
+}
+
+public static bool operator !=(AlphaModeEnum left, AlphaModeEnum right) {
+    return (left.Equals(right) == false);
+}
+
+public static implicit operator string(AlphaModeEnum value) {
+    return value.m_value;
+}
+
+public static implicit operator AlphaModeEnum(string value) {
+    return new AlphaModeEnum(value);
+}
+
+public class AlphaModeEnumConverter : System.Text.Json.Serialization.JsonConverter<AlphaModeEnum> {
+    public override AlphaModeEnum Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) {
+        if (reader.TokenType != System.Text.Json.JsonTokenType.String) {
+            throw new System.Text.Json.JsonException("Expected a string value for AlphaModeEnum.");
+        }
+        return new AlphaModeEnum(reader.GetString());
+    }
+    public override void Write(System.Text.Json.Utf8JsonWriter writer, AlphaModeEnum value, System.Text.Json.JsonSerializerOptions options) {
+        writer.WriteStringValue(value.m_value);
+    }
+}
+
         }
     }
 }

--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -62,11 +62,12 @@ namespace glTFLoaderUnitTests
 
                         using (var rb = new BinaryReader(s))
                         {
-                            uint header = rb.ReadUInt32();
+                            var header = rb.ReadBytes(4);
 
-                            if (header == 0x474e5089) continue; // PNG
-                            if ((header & 0xffff) == 0xd8ff) continue; // JPEG
-                            if (header == 0x46464952) continue; // WebP (RIFF)
+                            // Compare raw bytes to avoid depending on system endianness.
+                            if (header.Length >= 4 && header[0] == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47) continue; // PNG
+                            if (header.Length >= 2 && header[0] == 0xFF && header[1] == 0xD8) continue; // JPEG
+                            if (header.Length >= 4 && header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46) continue; // WebP (RIFF)
 
                             Assert.Fail($"Invalid image in Image index {i}");
                         }

--- a/glTFLoaderUnitTests/SampleModelsTest.cs
+++ b/glTFLoaderUnitTests/SampleModelsTest.cs
@@ -13,18 +13,6 @@ namespace glTFLoaderUnitTests
         private const string RelativePathToSchemaDir = @"..\..\..\..\..\glTF-Sample-Assets\Models\";
         private string AbsolutePathToSchemaDir;
 
-        // Models that require glTF extensions this loader does not yet support, so they cannot
-        // be loaded. Tracked by https://github.com/KhronosGroup/glTF-CSharp-Loader/issues/60.
-        private static readonly HashSet<string> UnsupportedModels = new HashSet<string>
-        {
-            "AnimatedColorsCube",         // KHR_animation_pointer
-            "AnimationPointerUVs",        // KHR_animation_pointer
-            "CubeVisibility",             // KHR_animation_pointer
-            "LightVisibility",            // KHR_animation_pointer
-            "PotOfCoalsAnimationPointer", // KHR_animation_pointer
-            "SheenWoodLeatherSofa",       // EXT_texture_webp
-        };
-
         public SampleModelsTest()
         {
             AbsolutePathToSchemaDir = Path.Combine(Directory.GetCurrentDirectory(), RelativePathToSchemaDir);
@@ -34,8 +22,6 @@ namespace glTFLoaderUnitTests
         {
             foreach (var dir in Directory.EnumerateDirectories(Path.GetFullPath(AbsolutePathToSchemaDir)))
             {
-                if (UnsupportedModels.Contains(Path.GetFileName(dir))) continue;
-
                 var xdir = Path.Combine(dir, subdir);
 
                 if (!Directory.Exists(xdir)) continue;
@@ -80,6 +66,7 @@ namespace glTFLoaderUnitTests
 
                             if (header == 0x474e5089) continue; // PNG
                             if ((header & 0xffff) == 0xd8ff) continue; // JPEG
+                            if (header == 0x46464952) continue; // WebP (RIFF)
 
                             Assert.Fail($"Invalid image in Image index {i}");
                         }


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context

The glTF schema defines several string properties as **open enums** — an `anyOf` with known `const` values plus a trailing bare `{ "type": "string" }`, meaning any string is valid so extensions may add values. The generator emitted these as strict C# enums, so models using extension-defined values failed to deserialize (the enum converter threw). This is what caused the models skipped in #59 to fail:

- `KHR_animation_pointer` sets the core animation channel `target.path` to `"pointer"`.
- `EXT_texture_webp` sets the core `image.mimeType` to `"image/webp"`.

## Change

Generate open string enums as a **"smart enum" struct** instead of a C# enum. The known values remain available as `static readonly` fields (e.g. `Material.AlphaModeEnum.OPAQUE`), so existing equality comparisons keep compiling, but any string now round-trips instead of throwing. Affected properties: `Accessor.Type`, `AnimationChannelTarget.Path`, `AnimationSampler.Interpolation`, `Camera.Type`, `Image.MimeType`, `Material.AlphaMode`.

- **Generator** flags open string enums (a bare `{ "type": "string" }` in the `anyOf`) and emits a `readonly` struct wrapping a string, with a `JsonConverter`. The converter must be `public` and — for colliding simple names (`Accessor.TypeEnum` / `Camera.TypeEnum`) — registered in the source-generated context, both required by System.Text.Json source generation with reflection disabled.
- **Loader** handles `image/webp` (mime detection from `.webp`/`data:image/webp` uris, embedded webp decode, `.webp` unpack extension). `KHR_animation_pointer` needs no loader code — the `path` struct now accepts `"pointer"`.
- The sample-asset models that use these extensions are un-skipped, and the loader test accepts the WebP (RIFF) image header.

Because these properties change from `enum` to `struct`, this is a breaking API change — appropriate for the 2.0.0 major release (which is still in preview).

Closes #60.


## Usage / migration

Reading and comparing known values is source-compatible — the values are still `X.YEnum.VALUE`, now `static readonly` fields instead of enum members:

```csharp
// Works the same before and after:
if (material.AlphaMode == Material.AlphaModeEnum.BLEND) { ... }
material.AlphaMode = Material.AlphaModeEnum.MASK;
```

The main break is `switch`: a struct's static fields can't be `case` labels, so switches must become `if`/`else` (or switch on `.Value`):

```csharp
// Before (enum):
switch (material.AlphaMode)
{
    case Material.AlphaModeEnum.OPAQUE: ...; break;
    case Material.AlphaModeEnum.MASK:   ...; break;
    case Material.AlphaModeEnum.BLEND:  ...; break;
}

// After (struct):
switch (material.AlphaMode.Value)   // switch on the raw string
{
    case "OPAQUE": ...; break;
    case "MASK":   ...; break;
    case "BLEND":  ...; break;
    default:       ...; break;      // extension / unknown values
}
```

Extension values that previously threw during `Interface.LoadModel(...)` now load, and can be read or assigned as strings:

```csharp
// Before: threw "The JSON value could not be converted to ...PathEnum".
// After: loads.
var path = model.Animations[0].Channels[0].Target.Path;
if (path == "pointer") { ... }      // implicit string comparison
Console.WriteLine(path.Value);      // "pointer"

image.MimeType = "image/webp";      // implicit string -> MimeTypeEnum
```
